### PR TITLE
Add content to README.md - add-user

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ When the hosted browser is started, it's enough to hit the 'refresh' button to r
 and verify changes. You can get the OOPHM Plugin, required for attaching your browser to the
 hosted mode execution here: http://gwt.google.com/samples/MissingPlugin/MissingPlugin.html
 
+NOTE: you need to add user with JBoss 8 add-user script.
 
 ## Running in web mode
 


### PR DESCRIPTION
If user is not defined (add-user.sh) GWT is thrown with empty model:

Unexpected HTTP response: 403

Request
{
    "operation" => "composite",
    "address" => [],
    "steps" => [
        {
            "operation" => "read-attribute",
            "name" => "process-type",
            "address" => []
        },
        {
            "operation" => "read-attribute",
            "name" => "product-version",
            "address" => []
        },
        {
            "operation" => "read-attribute",
            "name" => "release-version",
            "address" => []
        }
    ]
}

Response

Forbidden
No details
