### PR TITLE
HAL-405 Add Timeout Section to Datasources

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceEditor.java
@@ -60,6 +60,7 @@ public class DataSourceEditor {
     private FormEditor<DataSource> securityEditor;
     private DataSourceValidationEditor validationEditor;
     private DataSourceConnectionEditor connectionEditor;
+    private DataSourceTimeoutEditor<DataSource> timeoutEditor;
     private ToolButton disableBtn;
 
     public DataSourceEditor(DataSourcePresenter presenter) {
@@ -212,6 +213,12 @@ public class DataSourceEditor {
         validationEditor = new DataSourceValidationEditor(formCallback);
         validationEditor.getForm().bind(dataSourceTable.getCellTable());
         bottomPanel.add(validationEditor.asWidget(), "Validation");
+
+        // ----
+
+        timeoutEditor = new DataSourceTimeoutEditor<DataSource>(formCallback, false);
+        timeoutEditor.getForm().bind(dataSourceTable.getCellTable());
+        bottomPanel.add(timeoutEditor.asWidget(), "Timeouts");
 
         bottomPanel.selectTab(0);
 

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceTimeoutEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceTimeoutEditor.java
@@ -1,0 +1,118 @@
+package org.jboss.as.console.client.shared.subsys.jca;
+
+import org.jboss.as.console.client.shared.subsys.Baseadress;
+import org.jboss.as.console.client.shared.subsys.jca.model.DataSource;
+import org.jboss.as.console.client.shared.subsys.jca.model.XADataSource;
+import org.jboss.as.console.client.widgets.forms.FormEditor;
+import org.jboss.as.console.client.widgets.forms.FormToolStrip;
+import org.jboss.ballroom.client.widgets.forms.CheckBoxItem;
+import org.jboss.ballroom.client.widgets.forms.NumberBoxItem;
+import org.jboss.ballroom.client.widgets.forms.TextAreaItem;
+import org.jboss.ballroom.client.widgets.forms.TextBoxItem;
+import org.jboss.dmr.client.ModelNode;
+
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * @author Philippe Marschall
+ * @date 04/06/14
+ */
+public class DataSourceTimeoutEditor<T extends DataSource> extends FormEditor<T>{
+
+    private final boolean isXa;
+
+    public DataSourceTimeoutEditor(FormToolStrip.FormCallback<T> callback, boolean isXa) {
+
+        super(isXa ? XADataSource.class : DataSource.class);
+        this.isXa = isXa;
+
+        ModelNode helpAddress = Baseadress.get();
+        helpAddress.add("subsystem", "datasources");
+        if (isXa) {
+            helpAddress.add("xa-data-source", "*");
+        } else {
+            helpAddress.add("data-source", "*");
+        }
+
+        setCallback(callback);
+        setHelpAddress(helpAddress);
+    }
+
+    @Override
+    public Widget asWidget() {
+
+        NumberBoxItem useTryLock = new NumberBoxItem("useTryLock", "Use tryLock()") {
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        };
+
+        NumberBoxItem blockingTimeoutMillis  = new NumberBoxItem("blockingTimeoutWaitMillis", "Blocking Timeout Millis") {
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        };
+
+        NumberBoxItem idleTimeoutMinutes   = new NumberBoxItem("idleTimeoutMinutes", "Idle Timeout Minutes") {
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        };
+
+        CheckBoxItem setTxQueryTimeout = new CheckBoxItem("setTxQueryTimeout", "Set Tx Query Timeout") {
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        };
+
+        NumberBoxItem queryTimeout = new NumberBoxItem("queryTimeout", "Query Timeout") {
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        };
+
+        NumberBoxItem allocationRetry  = new NumberBoxItem("allocationRetry", "Allocation Retry") {
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        };
+
+        NumberBoxItem allocationRetryWaitMillis  = new NumberBoxItem("allocationRetryWaitMillis", "Allocation Retry Wait Millis") {
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        };
+
+        if (this.isXa) {
+
+            NumberBoxItem xaResourceTimeout   = new NumberBoxItem("xaResourceTimeout", "XA Resource Timeout") {
+                @Override
+                public boolean isRequired() {
+                    return false;
+                }
+            };
+            getForm().setFields(
+                    useTryLock,
+                    blockingTimeoutMillis, idleTimeoutMinutes,
+                    setTxQueryTimeout, queryTimeout,
+                    allocationRetry, allocationRetryWaitMillis, xaResourceTimeout);
+
+        } else {
+            getForm().setFields(
+                    useTryLock,
+                    blockingTimeoutMillis, idleTimeoutMinutes,
+                    setTxQueryTimeout, queryTimeout,
+                    allocationRetry, allocationRetryWaitMillis);
+        }
+
+        return super.asWidget();
+    }
+
+}

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/XADataSourceEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/XADataSourceEditor.java
@@ -35,6 +35,7 @@ import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.ProvidesKey;
 import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
+
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.shared.properties.PropertyEditor;
 import org.jboss.as.console.client.shared.properties.PropertyManagement;
@@ -71,6 +72,7 @@ public class XADataSourceEditor implements PropertyManagement {
     private XADataSourceConnection connectionEditor;
     private DataSourceSecurityEditor securityEditor;
     private DataSourceValidationEditor validationEditor;
+    private DataSourceTimeoutEditor<XADataSource> timeoutEditor;
     private ToolButton disableBtn;
 
     public XADataSourceEditor(DataSourcePresenter presenter) {
@@ -301,6 +303,10 @@ public class XADataSourceEditor implements PropertyManagement {
         validationEditor = new DataSourceValidationEditor(dsCallback);
         validationEditor.getForm().bind(dataSourceTable);
         bottomPanel.add(validationEditor.asWidget(), "Validation");
+
+        timeoutEditor = new DataSourceTimeoutEditor<XADataSource>(xaCallback, true);
+        timeoutEditor.getForm().bind(dataSourceTable);
+        bottomPanel.add(timeoutEditor.asWidget(), "Timeouts");
 
         bottomPanel.selectTab(0);
         vpanel.add(new ContentGroupLabel(Console.CONSTANTS.common_label_selection()));

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/model/DataSource.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/model/DataSource.java
@@ -145,4 +145,35 @@ public interface DataSource {
     @Binding(skip = true)
     String getTestConnection();
     void setTestConnection(String ignore);
+
+    // --
+
+    @Binding(detypedName = "use-try-lock")
+    long getUseTryLock();
+    void setUseTryLock(long l);
+
+    @Binding(detypedName = "blocking-timeout-wait-millis")
+    long getBlockingTimeoutWaitMillis();
+    void setBlockingTimeoutWaitMillis(long l);
+
+    @Binding(detypedName = "idle-timeout-minutes")
+    long getIdleTimeoutMinutes();
+    void setIdleTimeoutMinutes(long l);
+
+    @Binding(detypedName = "set-tx-query-timeout")
+    boolean isSetTxQueryTimeout();
+    void setSetTxQueryTimeout(boolean b);
+
+    @Binding(detypedName = "query-timeout")
+    long getQueryTimeout();
+    void setQueryTimeout(long l);
+
+    @Binding(detypedName = "allocation-retry")
+    int getAllocationRetry();
+    void setAllocationRetry(int i);
+
+    @Binding(detypedName = "allocation-retry-wait-millis")
+    long getAllocationRetryWaitMillis();
+    void setAllocationRetryWaitMillis(long l);
+
 }

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/model/XADataSource.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/model/XADataSource.java
@@ -60,4 +60,7 @@ public interface XADataSource extends DataSource {
     boolean isEnableInterleave();
     void setEnableInterleave(boolean b);
 
+    @Binding(detypedName = "xa-resource-timeout")
+    int getXaResourceTimeout();
+    void setXaResourceTimeout(int i);
 }


### PR DESCRIPTION
Add a new section to the datasource configuration that allows to set
the values from the `<timeout/>` element in the configuration. The
section contains the following attributes:
- use-try-lock (long)
- blocking-timeout-millis (long)
- idle-timeout-minutes (long)
- set-tx-query-timeout (boolean)
- query-timeout (long)
- allocation-retry (int)
- allocation-retry-wait-millis (long)
- xa-resource-timeout (int), only for XA

Issue:
https://issues.jboss.org/browse/HAL-405
