### PR TITLE
[HAL-666] set enableAfterDeployment to true in domain mode

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/deployment/DeploymentStep2.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/deployment/DeploymentStep2.java
@@ -64,7 +64,11 @@ public class DeploymentStep2 {
         TextBoxItem nameField = new TextBoxItem("name", Console.CONSTANTS.common_label_name());
         TextBoxItem runtimeNameField = new TextBoxItem("runtimeName", Console.CONSTANTS.common_label_runtimeName());
         CheckBoxItem enable = new CheckBoxItem("enableAfterDeployment", "Enable");
-        form.setFields(nameField, runtimeNameField, enable);
+        if (Console.getBootstrapContext().isStandalone()) {
+            form.setFields(nameField, runtimeNameField, enable);
+        } else {
+            form.setFields(nameField, runtimeNameField);
+        }
 
         layout.add(form.asWidget());
 

--- a/gui/src/main/java/org/jboss/as/console/client/shared/deployment/NewDeploymentWizard.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/deployment/NewDeploymentWizard.java
@@ -195,7 +195,7 @@ public class NewDeploymentWizard {
         sb.append("\"BYTES_VALUE\":\"").append(deployment.getHash()).append("\"");
         sb.append("}}],");
         sb.append("\"name\":\"").append(deployment.getName()).append("\",");
-        sb.append("\"enabled\":\"").append(deployment.isEnableAfterDeployment()).append("\"");
+        sb.append("\"enabled\":\"").append(Console.getBootstrapContext().isStandalone() ? deployment.isEnableAfterDeployment() : true).append("\"");
         sb.append("}");
         return sb.toString();
     }
@@ -210,7 +210,7 @@ public class NewDeploymentWizard {
         sb.append("}}],");
         sb.append("\"name\":\"").append(deployment.getName()).append("\",");
         sb.append("\"runtime-name\":\"").append(deployment.getRuntimeName()).append("\",");
-        sb.append("\"enabled\":\"").append(deployment.isEnableAfterDeployment()).append("\"");
+        sb.append("\"enabled\":\"").append(Console.getBootstrapContext().isStandalone() ? deployment.isEnableAfterDeployment() : true).append("\"");
         sb.append("}");
         return sb.toString();
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-666 Previously, CheckBoxItem "enable" is not added in domain mode and application replacement is not enabled by default.

commit https://github.com/hal/core/commit/83e37fbd365ab7f307c1d5f09412809ecb796462 exposed  that CheckBoxItem. Thus, customer can choose to un-check it. It should remove that filed and add a true value by default once it's on domain mode.
