### PR TITLE
[HAL-757] Server-group-scoped-roles not respected in Domain mode

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/domain/groups/deployment/DomainDeploymentPresenter.java
+++ b/gui/src/main/java/org/jboss/as/console/client/domain/groups/deployment/DomainDeploymentPresenter.java
@@ -335,6 +335,14 @@ public class DomainDeploymentPresenter extends Presenter<DomainDeploymentPresent
                 }
                 refreshDeployments();
             }
+
+            @Override
+            public void onFailure(Throwable caught) {
+                loading.hide();
+                String header = Console.MESSAGES.failedToRemoveFrom(deployment.getName(),
+                        Console.CONSTANTS.common_label_contentRepository());
+                Console.error(header, caught.getMessage());
+            }
         });
     }
 

--- a/gui/src/main/java/org/jboss/as/console/mbui/model/mapping/AddressMapping.java
+++ b/gui/src/main/java/org/jboss/as/console/mbui/model/mapping/AddressMapping.java
@@ -1,15 +1,13 @@
 package org.jboss.as.console.mbui.model.mapping;
 
-import static org.jboss.dmr.client.ModelDescriptionConstants.ADDRESS;
-
+import com.allen_sauer.gwt.log.client.Log;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-
-import com.allen_sauer.gwt.log.client.Log;
+import static org.jboss.dmr.client.ModelDescriptionConstants.ADDRESS;
 import org.jboss.dmr.client.ModelNode;
 import org.useware.kernel.gui.behaviour.StatementContext;
 
@@ -214,9 +212,23 @@ public class AddressMapping {
                 {
                     value_ref = value_ref.substring(1, value_ref.length()-1);
 
-                    if(!valueMemory.contains(value_ref))
-                        valueMemory.memorize(value_ref, context.collect(value_ref));
+                    int entries = 0;
+                    if(!valueMemory.contains(value_ref)) {
+                        LinkedList<String> values = context.collect(value_ref);
+                        entries = values.size();
+                        valueMemory.memorize(value_ref, values);
+                    }
 
+                    if (entries > 1 && value_ref.equalsIgnoreCase("addressable.group")) {
+
+                        ModelNode addresses = new ModelNode();
+                        addresses.setEmptyList();
+                        while ((resolved_value = valueMemory.next(value_ref)) != null) {
+                            addresses.add(resolved_value);
+                        }
+                        model.get(ADDRESS).add(resolved_key, addresses);
+                        continue;
+                    }
                     resolved_value= valueMemory.next(value_ref);
                 }
                 else

--- a/gui/src/main/java/org/useware/kernel/gui/behaviour/FilteringStatementContext.java
+++ b/gui/src/main/java/org/useware/kernel/gui/behaviour/FilteringStatementContext.java
@@ -1,5 +1,6 @@
 package org.useware.kernel.gui.behaviour;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 
 /**
@@ -50,21 +51,9 @@ public class FilteringStatementContext implements StatementContext {
     @Override
     public LinkedList<String> collect(String key) {
         LinkedList<String> actualCollection = delegate.collect(key);
-        String filtered = filter.filter(key);
-        if(filtered!=null)
-        {
-            LinkedList<String> filteredCollection = new LinkedList<String>();
-            for(String val : actualCollection)
-            {
-                filteredCollection.add(filtered);
-            }
-
-            //TODO: this currently enforces a filter to be applied (hack?)
-            if(actualCollection.isEmpty())
-                filteredCollection.add(filtered);
-
-            return filteredCollection;
-        }
+        String[] filtered = filter.filterTuple(key);
+        if(null != filtered)
+            return new LinkedList<>(Arrays.asList(filtered));
 
         return actualCollection;
     }


### PR DESCRIPTION
Server-group modify buttons now appear for all users who are part of a valid server-group. If the user does not have the appropriate write permissions for a specific deployment/group, then the request will fail and a console message will be displayed.

Request processing panel is now hidden when a deployment cannot be removed from the Content Repository.