### PR TITLE
BZ1235034: Resource adapter properties are invisible in Web Admin Console

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/AdapterConnectionDetails.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/AdapterConnectionDetails.java
@@ -73,11 +73,8 @@ public class AdapterConnectionDetails {
                 }, form
         );
         layout.add(helpPanel.asWidget());
-
+        form.setEnabled(true);
         layout.add(form.asWidget());
-
-        form.setEnabled(false   );
-
     }
 
     Widget asWidget() {


### PR DESCRIPTION
Back port of the fix to maintenance branch for EAP