### PR TITLE
[HAL-774] JVM attributes heapSize and maxHeapSize should be nillable.

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/domain/hosts/general/NewHostJvmWizard.java
+++ b/gui/src/main/java/org/jboss/as/console/client/domain/hosts/general/NewHostJvmWizard.java
@@ -56,8 +56,8 @@ public class NewHostJvmWizard {
         final Form<Jvm> form = new Form<Jvm>(Jvm.class);
 
         TextBoxItem nameItem = new TextBoxItem("name", Console.CONSTANTS.common_label_name());
-        HeapBoxItem heapItem = new HeapBoxItem("heapSize", "Heap Size");
-        HeapBoxItem maxHeapItem = new HeapBoxItem("maxHeapSize", "Max Heap Size");
+        HeapBoxItem heapItem = new HeapBoxItem("heapSize", "Heap Size", false);
+        HeapBoxItem maxHeapItem = new HeapBoxItem("maxHeapSize", "Max Heap Size", false);
         HeapBoxItem permgen = new HeapBoxItem("permgen", "Permgen Size", false);
         HeapBoxItem maxPermgen = new HeapBoxItem("maxPermgen", "Max Permgen Size", false);
 

--- a/gui/src/main/java/org/jboss/as/console/client/shared/jvm/CreateJvmCmd.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/jvm/CreateJvmCmd.java
@@ -54,8 +54,12 @@ public class CreateJvmCmd extends AddressableModelCmd implements AsyncCommand<Bo
         operation.get(ADDRESS).set(address);
 
         //ModelNode jvmModel = new ModelNode();
-        operation.get("heap-size").set(jvm.getHeapSize());
-        operation.get("max-heap-size").set(jvm.getMaxHeapSize());
+        if (jvm.getPermgen() != null && jvm.getPermgen().trim().length() != 0) {
+            operation.get("heap-size").set(jvm.getPermgen());
+        }
+        if (jvm.getPermgen() != null && jvm.getPermgen().trim().length() != 0) {
+            operation.get("max-heap-size").set(jvm.getPermgen());
+        }
         operation.get("debug-enabled").set(jvm.isDebugEnabled());
         if (jvm.getPermgen() != null && jvm.getPermgen().trim().length() != 0) {
             operation.get("permgen-size").set(jvm.getPermgen());

--- a/gui/src/main/java/org/jboss/as/console/client/shared/jvm/JvmEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/jvm/JvmEditor.java
@@ -149,8 +149,8 @@ public class JvmEditor {
         else
             nameItem = new TextItem("name", Console.CONSTANTS.common_label_name());
 
-        HeapBoxItem heapItem = new HeapBoxItem("heapSize", "Heap Size");
-        HeapBoxItem maxHeapItem = new HeapBoxItem("maxHeapSize", "Max Heap Size");
+        HeapBoxItem heapItem = new HeapBoxItem("heapSize", "Heap Size", false);
+        HeapBoxItem maxHeapItem = new HeapBoxItem("maxHeapSize", "Max Heap Size", false);
         HeapBoxItem maxPermgen = new HeapBoxItem("maxPermgen", "Max Permgen Size", false);
         HeapBoxItem permgen = new HeapBoxItem("permgen", "Permgen Size", false);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-774 and https://bugzilla.redhat.com/show_bug.cgi?id=1248009

heapSize and maxHeapSize are nillable attributes, They should accept undefined values in console as CLI instance does.
            "heap-size" => {
                ...
                "nillable" => true,
                ...
            },
            "max-heap-size" => {
                ...
                "nillable" => true,
                ...
            },