### PR TITLE
[HAL-788] Remote socket binding is not displayed if it's port uses a …

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/general/model/RemoteSocketBinding.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/general/model/RemoteSocketBinding.java
@@ -12,6 +12,7 @@ public interface RemoteSocketBinding {
     String getName();
     void setName(String name);
 
+    @Binding(expr = true)
     int getPort();
     void setPort(int port);
 


### PR DESCRIPTION
…property expression

Port of hal/core#55 to the maintenance branch