### PR TITLE
[HAL-764] Unable to unset wsdl-port and wsdl-secure-port via console

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/mbui/widgets/ModelNodeForm.java
+++ b/gui/src/main/java/org/jboss/as/console/mbui/widgets/ModelNodeForm.java
@@ -208,6 +208,11 @@ public class ModelNodeForm extends AbstractForm<ModelNode> {
     public static Object downCast(ModelNode value, ModelNode metadata)
     {
         Object result = null;
+
+        if (!value.isDefined()) { // value.asXxx() throws IllegalArgumentException when value is undefined
+            return FormItem.VALUE_SEMANTICS.UNDEFINED;
+        }
+
         ModelType targetType = resolveTypeFromMetaData(metadata);
         switch (targetType)
         {


### PR DESCRIPTION
ModelValue.asInt() was throwing IllegalArgumentException when value was was undefined.

I'm returning FormItem.VALUE_SEMANTICS.UNDEFINED, because that is what ModelNodeForm.getChangedValues() would use anyway at https://github.com/hal/core/blob/master/gui/src/main/java/org/jboss/as/console/mbui/widgets/ModelNodeForm.java#L389.

Also, the IllegalArgumentException is not caught anywhere and is not communicated to user, so it seems as if operation was successful, except the green confirmation panel is not displayed. Not sure where to fix that.