### PR TITLE
[BZ-1256819] Incorrect display of application name while assigning a new application to the ServerGroup.

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/domain/groups/deployment/ContentRepositoryPanel.java
+++ b/gui/src/main/java/org/jboss/as/console/client/domain/groups/deployment/ContentRepositoryPanel.java
@@ -236,6 +236,7 @@ public class ContentRepositoryPanel implements IsWidget
 
     void reset(final ContentRepository contentRepository)
     {
+    	
         this.contentRepository = contentRepository;
         List<DeploymentRecord> _deployments = contentRepository.getDeployments();
         Collections.sort(_deployments, new Comparator<DeploymentRecord>() {
@@ -244,6 +245,7 @@ public class ContentRepositoryPanel implements IsWidget
                 return d1.getName().toLowerCase().compareTo(d2.getName().toLowerCase());
             }
         });
+        this.deploymentSelection.clear();
         this.deploymentData.setList(_deployments);
         this.deploymentsTable.selectDefaultEntity();
         this.filter.reset();


### PR DESCRIPTION
BZ 6.4.z: https://bugzilla.redhat.com/show_bug.cgi?id=1256819
No upstream required

Clearing up the selection model during reset.