### PR TITLE
[HAL-856] DataSources - use test-connection-in-pool op for determining verify button privilegues

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/runtime/ds/DataSourceMetrics.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/runtime/ds/DataSourceMetrics.java
@@ -167,6 +167,11 @@ public class DataSourceMetrics {
 
         verifyBtn.setVisible(true);
         verifyBtn.ensureDebugId(Console.DEBUG_CONSTANTS.debug_label_verify_dataSourceDetails());
+        if (isXA) {
+            verifyBtn.setOperationAddress("/{selected.host}/{selected.server}/subsystem=datasources/xa-data-source=*", "test-connection-in-pool");
+        } else {
+            verifyBtn.setOperationAddress("/{selected.host}/{selected.server}/subsystem=datasources/data-source=*", "test-connection-in-pool");
+        }
         tools.addToolButtonRight(verifyBtn);
         tools.addToolWidgetRight(flushDropdown);
         tools.setVisible(true);


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/HAL-856
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1243175