### PR TITLE
[HAL-856] DataSources - use test-connection-in-pool op for determining  verify button privilegues

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceConnectionEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceConnectionEditor.java
@@ -83,6 +83,7 @@ public class DataSourceConnectionEditor {
         });
 
         verifyBtn.ensureDebugId(Console.DEBUG_CONSTANTS.debug_label_verify_dataSourceDetails());
+        verifyBtn.setOperationAddress("/{selected.profile}/subsystem=datasources/data-source=*", "test-connection-in-pool");
 
         FormToolStrip<DataSource> formTools = new FormToolStrip<DataSource>(form,callback);
         formTools.providesDeleteOp(false);

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/XADataSourceConnection.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/XADataSourceConnection.java
@@ -78,7 +78,7 @@ public class XADataSourceConnection {
             }
         });
         verifyBtn.ensureDebugId(Console.DEBUG_CONSTANTS.debug_label_verify_xADataSourceDetails());
-
+        verifyBtn.setOperationAddress("/{selected.profile}/subsystem=datasources/xa-data-source=*", "test-connection-in-pool");
 
         FormToolStrip<XADataSource> formTools = new FormToolStrip<XADataSource>(form, callback);
         formTools.providesDeleteOp(false);


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/HAL-856
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1243175
