### PR TITLE
BZ1201685: Deployments name shortened in admin console of Jboss EAP 6 (followup)

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/domain/groups/deployment/AssignToGroupWizard.java
+++ b/gui/src/main/java/org/jboss/as/console/client/domain/groups/deployment/AssignToGroupWizard.java
@@ -70,12 +70,7 @@ public class AssignToGroupWizard {
         TextColumn<DeploymentRecord> titleColumn = new TextColumn<DeploymentRecord>() {
             @Override
             public String getValue(DeploymentRecord record) {
-                String title = null;
-                if(record.getRuntimeName().length()>37)
-                    title = record.getRuntimeName().substring(0,36)+"...";
-                else
-                    title = record.getRuntimeName();
-                return title;
+                return record.getRuntimeName();
             }
         };
 


### PR DESCRIPTION
My previous commit did not really fixed the issue has expected. This one is (or at least should). 

No PR is needed for upstream.