### PR TITLE
[HAL-776] Unnecessary validation of numeric fields forces user to man…

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/infinispan/model/DistributedCache.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/infinispan/model/DistributedCache.java
@@ -167,7 +167,7 @@ public interface DistributedCache extends ReplicatedCache {
     @Binding(detypedName="locking/LOCKING/acquire-timeout")
     @FormItem(defaultValue="15000",
             label="Acquire Timeout (ms)",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_locking")
@@ -179,7 +179,7 @@ public interface DistributedCache extends ReplicatedCache {
     @Binding(detypedName="locking/LOCKING/concurrency-level")
     @FormItem(defaultValue="1000",
             label="Concurrency Level",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_locking")
@@ -302,7 +302,7 @@ public interface DistributedCache extends ReplicatedCache {
     @Binding(detypedName="expiration/EXPIRATION/max-idle")
     @FormItem(defaultValue="-1",
             label="Max Idle",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX_ALLOW_NEGATIVE",
             formItemTypeForAdd="NUMBER_BOX_ALLOW_NEGATIVE",
             localTabName ="subsys_infinispan_expiration")
@@ -314,7 +314,7 @@ public interface DistributedCache extends ReplicatedCache {
     @Binding(detypedName="expiration/EXPIRATION/lifespan")
     @FormItem(defaultValue="-1",
             label="Lifespan",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX_ALLOW_NEGATIVE",
             formItemTypeForAdd="NUMBER_BOX_ALLOW_NEGATIVE",
             localTabName ="subsys_infinispan_expiration")
@@ -326,7 +326,7 @@ public interface DistributedCache extends ReplicatedCache {
     @Binding(detypedName="expiration/EXPIRATION/interval")
     @FormItem(defaultValue="5000",
             label="Interval",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX_ALLOW_NEGATIVE",
             formItemTypeForAdd="NUMBER_BOX_ALLOW_NEGATIVE",
             localTabName ="subsys_infinispan_expiration")
@@ -779,7 +779,7 @@ public interface DistributedCache extends ReplicatedCache {
     @Binding(detypedName="queue-size")
     @FormItem(defaultValue="1000",
             label="Queue Size",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_attrs")
@@ -791,7 +791,7 @@ public interface DistributedCache extends ReplicatedCache {
     @Binding(detypedName="queue-flush-interval")
     @FormItem(defaultValue="10",
             label="Queue Flush Interval",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_attrs")
@@ -803,7 +803,7 @@ public interface DistributedCache extends ReplicatedCache {
     @Binding(detypedName="remote-timeout")
     @FormItem(defaultValue="17500",
             label="Remote Timeout (ms)",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_attrs")

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/infinispan/model/InvalidationCache.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/infinispan/model/InvalidationCache.java
@@ -167,7 +167,7 @@ public interface InvalidationCache extends LocalCache {
     @Binding(detypedName="locking/LOCKING/acquire-timeout")
     @FormItem(defaultValue="15000",
             label="Acquire Timeout (ms)",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_locking")
@@ -179,7 +179,7 @@ public interface InvalidationCache extends LocalCache {
     @Binding(detypedName="locking/LOCKING/concurrency-level")
     @FormItem(defaultValue="1000",
             label="Concurrency Level",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_locking")
@@ -302,7 +302,7 @@ public interface InvalidationCache extends LocalCache {
     @Binding(detypedName="expiration/EXPIRATION/max-idle")
     @FormItem(defaultValue="-1",
             label="Max Idle",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX_ALLOW_NEGATIVE",
             formItemTypeForAdd="NUMBER_BOX_ALLOW_NEGATIVE",
             localTabName ="subsys_infinispan_expiration")
@@ -314,7 +314,7 @@ public interface InvalidationCache extends LocalCache {
     @Binding(detypedName="expiration/EXPIRATION/lifespan")
     @FormItem(defaultValue="-1",
             label="Lifespan",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX_ALLOW_NEGATIVE",
             formItemTypeForAdd="NUMBER_BOX_ALLOW_NEGATIVE",
             localTabName ="subsys_infinispan_expiration")
@@ -326,7 +326,7 @@ public interface InvalidationCache extends LocalCache {
     @Binding(detypedName="expiration/EXPIRATION/interval")
     @FormItem(defaultValue="5000",
             label="Interval",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX_ALLOW_NEGATIVE",
             formItemTypeForAdd="NUMBER_BOX_ALLOW_NEGATIVE",
             localTabName ="subsys_infinispan_expiration")
@@ -776,7 +776,7 @@ public interface InvalidationCache extends LocalCache {
     @Binding(detypedName="queue-size")
     @FormItem(defaultValue="1000",
             label="Queue Size",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_attrs")
@@ -786,7 +786,7 @@ public interface InvalidationCache extends LocalCache {
     @Binding(detypedName="queue-flush-interval")
     @FormItem(defaultValue="10",
             label="Queue Flush Interval",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_attrs")
@@ -796,7 +796,7 @@ public interface InvalidationCache extends LocalCache {
     @Binding(detypedName="remote-timeout")
     @FormItem(defaultValue="17500",
             label="Remote Timeout (ms)",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_attrs")

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/infinispan/model/ReplicatedCache.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/infinispan/model/ReplicatedCache.java
@@ -168,7 +168,7 @@ public interface ReplicatedCache extends InvalidationCache {
     @Binding(detypedName="locking/LOCKING/acquire-timeout")
     @FormItem(defaultValue="15000",
             label="Acquire Timeout (ms)",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_locking")
@@ -180,7 +180,7 @@ public interface ReplicatedCache extends InvalidationCache {
     @Binding(detypedName="locking/LOCKING/concurrency-level")
     @FormItem(defaultValue="1000",
             label="Concurrency Level",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_locking")
@@ -303,7 +303,7 @@ public interface ReplicatedCache extends InvalidationCache {
     @Binding(detypedName="expiration/EXPIRATION/max-idle")
     @FormItem(defaultValue="-1",
             label="Max Idle",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX_ALLOW_NEGATIVE",
             formItemTypeForAdd="NUMBER_BOX_ALLOW_NEGATIVE",
             localTabName ="subsys_infinispan_expiration")
@@ -315,7 +315,7 @@ public interface ReplicatedCache extends InvalidationCache {
     @Binding(detypedName="expiration/EXPIRATION/lifespan")
     @FormItem(defaultValue="-1",
             label="Lifespan",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX_ALLOW_NEGATIVE",
             formItemTypeForAdd="NUMBER_BOX_ALLOW_NEGATIVE",
             localTabName ="subsys_infinispan_expiration")
@@ -327,7 +327,7 @@ public interface ReplicatedCache extends InvalidationCache {
     @Binding(detypedName="expiration/EXPIRATION/interval")
     @FormItem(defaultValue="5000",
             label="Interval",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX_ALLOW_NEGATIVE",
             formItemTypeForAdd="NUMBER_BOX_ALLOW_NEGATIVE",
             localTabName ="subsys_infinispan_expiration")
@@ -780,7 +780,7 @@ public interface ReplicatedCache extends InvalidationCache {
     @Binding(detypedName="queue-size")
     @FormItem(defaultValue="1000",
             label="Queue Size",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_attrs")
@@ -792,7 +792,7 @@ public interface ReplicatedCache extends InvalidationCache {
     @Binding(detypedName="queue-flush-interval")
     @FormItem(defaultValue="10",
             label="Queue Flush Interval",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_attrs")
@@ -804,7 +804,7 @@ public interface ReplicatedCache extends InvalidationCache {
     @Binding(detypedName="remote-timeout")
     @FormItem(defaultValue="17500",
             label="Remote Timeout (ms)",
-            required=true,
+            required=false,
             formItemTypeForEdit="NUMBER_BOX",
             formItemTypeForAdd="NUMBER_BOX",
             localTabName ="subsys_infinispan_attrs")


### PR DESCRIPTION
…ually enter even default values when configuring infinispan subsystem

Now applies to invalidation, replicated and distributed caches.