### PR TITLE
[HAL-893] Impossible to disable usage data collection by web console.

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/core/settings/SettingsPresenterWidget.java
+++ b/gui/src/main/java/org/jboss/as/console/client/core/settings/SettingsPresenterWidget.java
@@ -41,6 +41,7 @@ public class SettingsPresenterWidget extends PresenterWidget<SettingsPresenterWi
 
     public interface MyView extends PopupView {
         void setPresenter(SettingsPresenterWidget presenter);
+        void setFormValues(CommonSettings settings);
     }
 
 
@@ -86,5 +87,11 @@ public class SettingsPresenterWidget extends PresenterWidget<SettingsPresenterWi
         settings.setAnalytics(Boolean.valueOf(Preferences.get(Preferences.Key.ANALYTICS, analyticsDefault)));
         settings.setSecurityCache(Boolean.valueOf(Preferences.get(Preferences.Key.SECURITY_CONTEXT, "true")));
         return settings;
+    }
+
+    @Override
+    protected void onReveal() {
+        super.onReveal();
+        getView().setFormValues(getCommonSettings());
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/core/settings/SettingsView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/core/settings/SettingsView.java
@@ -207,9 +207,8 @@ public class SettingsView extends PopupViewImpl implements SettingsPresenterWidg
     }
 
     @Override
-    public void show() {
-        super.show();
-        form.edit(presenter.getCommonSettings());
+    public void setFormValues(CommonSettings settings) {
+        form.edit(settings);
         if(clear!=null) {
             clear.setEnabled(true);
             clearDisabled = false;


### PR DESCRIPTION
Problem was that PopupViewImpl#showAndReposition() was called instead of #show(), so the overridden method in SettingsView was not invoked.

https://issues.jboss.org/browse/HAL-893
https://issues.jboss.org/browse/JBEAP-1377