### PR TITLE
HAL-910, JBEAP-1504: Resource focus change after edit is confusing

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/BeanPoolView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/BeanPoolView.java
@@ -6,6 +6,7 @@ import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.ProvidesKey;
 import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.jboss.as.console.client.Console;
@@ -40,8 +41,9 @@ public class BeanPoolView {
 
     public BeanPoolView(EJB3Presenter presenter) {
         this.presenter = presenter;
-        this.table = new DefaultCellTable(5);
-        this.dataProvider = new ListDataProvider<Property>();
+        ProvidesKey<Property> providesKey = Property::getName;
+        this.table = new DefaultCellTable(5, providesKey);
+        this.dataProvider = new ListDataProvider<>(providesKey);
         this.dataProvider.addDataDisplay(table);
     }
 
@@ -149,8 +151,8 @@ public class BeanPoolView {
     }
 
     public void setData(List<Property> data) {
-        selectionModel.clear();
         dataProvider.setList(data);
         table.selectDefaultEntity();
+        SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/CachesView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/CachesView.java
@@ -5,7 +5,9 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.view.client.HasData;
 import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.ProvidesKey;
 import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.jboss.as.console.client.Console;
@@ -40,8 +42,9 @@ public class CachesView {
 
     public CachesView(EJB3Presenter presenter) {
         this.presenter = presenter;
-        this.table = new DefaultCellTable(5);
-        this.dataProvider = new ListDataProvider<Property>();
+        ProvidesKey<Property> providesKey = Property::getName;
+        this.table = new DefaultCellTable<>(5, providesKey);
+        this.dataProvider = new ListDataProvider<>(providesKey);
         this.dataProvider.addDataDisplay(table);
     }
 
@@ -141,8 +144,8 @@ public class CachesView {
     }
 
     public void setData(List<Property> data) {
-        selectionModel.clear();
         dataProvider.setList(data);
         table.selectDefaultEntity();
+        SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/EJB3Presenter.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/EJB3Presenter.java
@@ -60,7 +60,7 @@ public class EJB3Presenter extends Presenter<EJB3Presenter.MyView, EJB3Presenter
 
         @Override
         public void onFailure(AddressTemplate address, String name, Throwable t) {
-            Console.info("Failed to save resource "+address.resolve(statementContext, name)+": "+t.getMessage());
+            Console.error("Failed to save resource "+address.resolve(statementContext, name)+": "+t.getMessage());
         }
     };
 

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/PassivationView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/PassivationView.java
@@ -127,7 +127,7 @@ public class PassivationView {
                 .addDetail("Attributes", formPanel);
 
 
-        selectionModel = new SingleSelectionModel<Property>();
+        selectionModel = new SingleSelectionModel<>(keyprovider);
         selectionModel.addSelectionChangeHandler(new SelectionChangeEvent.Handler() {
             @Override
             public void onSelectionChange(SelectionChangeEvent event) {
@@ -152,8 +152,8 @@ public class PassivationView {
     }
 
     public void setData(List<Property> data) {
-        selectionModel.clear();
         dataProvider.setList(data);
         table.selectDefaultEntity();
+        SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/RemotingProfileView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/RemotingProfileView.java
@@ -6,6 +6,7 @@ import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.ProvidesKey;
 import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.jboss.as.console.client.Console;
@@ -41,8 +42,9 @@ public class RemotingProfileView {
 
     public RemotingProfileView(EJB3Presenter presenter) {
         this.presenter = presenter;
-        this.table = new DefaultCellTable(5);
-        this.dataProvider = new ListDataProvider<Property>();
+        ProvidesKey<Property> providesKey = Property::getName;
+        this.table = new DefaultCellTable<>(5, providesKey);
+        this.dataProvider = new ListDataProvider<>(providesKey);
         this.dataProvider.addDataDisplay(table);
     }
 
@@ -142,8 +144,8 @@ public class RemotingProfileView {
     }
 
     public void setData(List<Property> data) {
-        selectionModel.clear();
         dataProvider.setList(data);
         table.selectDefaultEntity();
+        SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/ServiceViewTemplate.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/ServiceViewTemplate.java
@@ -6,6 +6,7 @@ import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.ProvidesKey;
 import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.jboss.as.console.client.Console;
@@ -44,8 +45,9 @@ public class ServiceViewTemplate {
         this.title = title;
         this.presenter = presenter;
         this.address = address;
-        this.table = new DefaultCellTable(5);
-        this.dataProvider = new ListDataProvider<Property>();
+        ProvidesKey<Property> providesKey = Property::getName;
+        this.table = new DefaultCellTable<>(5, providesKey);
+        this.dataProvider = new ListDataProvider<>(providesKey);
         this.dataProvider.addDataDisplay(table);
     }
 
@@ -147,9 +149,9 @@ public class ServiceViewTemplate {
 
     public void setData(List<Property> data) {
         if(selectionModel!=null) {
-            selectionModel.clear();
             dataProvider.setList(data);
             table.selectDefaultEntity();
+            SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
         }
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/ThreadPoolView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/ejb3/ThreadPoolView.java
@@ -6,6 +6,7 @@ import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.ProvidesKey;
 import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.jboss.as.console.client.Console;
@@ -41,8 +42,9 @@ public class ThreadPoolView {
 
     public ThreadPoolView(EJB3Presenter presenter) {
         this.presenter = presenter;
-        this.table = new DefaultCellTable(5);
-        this.dataProvider = new ListDataProvider<Property>();
+        ProvidesKey<Property> providesKey = Property::getName;
+        this.table = new DefaultCellTable<>(5, providesKey);
+        this.dataProvider = new ListDataProvider<>(providesKey);
         this.dataProvider.addDataDisplay(table);
     }
 
@@ -150,8 +152,8 @@ public class ThreadPoolView {
     }
 
     public void setData(List<Property> data) {
-        selectionModel.clear();
         dataProvider.setList(data);
         table.selectDefaultEntity();
+        SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/infinispan/v3/CommonCacheAttributes.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/infinispan/v3/CommonCacheAttributes.java
@@ -251,14 +251,9 @@ public class CommonCacheAttributes {
     }
 
     public void updateFrom(List<Property> properties) {
-
-        resetForms();
-        selectionModel.clear();
-
         dataProvider.setList(properties);
-
         table.selectDefaultEntity();
-
+        updateForms(selectionModel.getSelectedObject());
     }
 
     class AddressableFormCallback implements FormCallback<ModelNode> {

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/io/IOPanel.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/io/IOPanel.java
@@ -175,5 +175,6 @@ public abstract class IOPanel extends SuspendableViewImpl {
         } else {
             table.selectDefaultEntity();
         }
+        SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jberet/ui/MasterDetailPanel.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jberet/ui/MasterDetailPanel.java
@@ -27,6 +27,7 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.ProvidesKey;
+import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.layout.OneToOneLayout;
@@ -233,9 +234,9 @@ public abstract class MasterDetailPanel implements IsWidget {
     }
 
     protected void update(final List<Property> models) {
-        selectionModel.clear();
         dataProvider.setList(models);
         table.selectDefaultEntity();
+        SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
     }
 
     protected abstract void dispatchAdd(final Dispatcher circuit, final Property property);

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/JcaBootstrapEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/JcaBootstrapEditor.java
@@ -7,6 +7,7 @@ import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.ProvidesKey;
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.layout.MultipleToOneLayout;
 import org.jboss.as.console.client.shared.help.FormHelpPanel;
@@ -47,8 +48,9 @@ public class JcaBootstrapEditor {
         final Form<JcaBootstrapContext> form = new Form<JcaBootstrapContext>(JcaBootstrapContext.class);
         form.setEnabled(false);
 
-        table = new DefaultCellTable<JcaBootstrapContext>(10);
-        dataProvider = new ListDataProvider<JcaBootstrapContext>();
+        ProvidesKey<JcaBootstrapContext> providesKey = JcaBootstrapContext::getName;
+        table = new DefaultCellTable<>(10, providesKey);
+        dataProvider = new ListDataProvider<>(providesKey);
         dataProvider.addDataDisplay(table);
 
         TextColumn<JcaBootstrapContext> name = new TextColumn<JcaBootstrapContext>() {

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/ThreadPoolEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/ThreadPoolEditor.java
@@ -6,6 +6,7 @@ import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.ProvidesKey;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.layout.FormLayout;
@@ -56,9 +57,11 @@ public class ThreadPoolEditor {
     }
 
     Widget asWidget() {
-        table = new DefaultCellTable<WorkmanagerPool>(10);
+        ProvidesKey<WorkmanagerPool> providesKey = WorkmanagerPool::getName;
 
-        dataProvider = new ListDataProvider<WorkmanagerPool>();
+        table = new DefaultCellTable<>(10, providesKey);
+
+        dataProvider = new ListDataProvider<>(providesKey);
         dataProvider.addDataDisplay(table);
 
         TextColumn<WorkmanagerPool> name = new TextColumn<WorkmanagerPool>() {

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/logger/CategoryView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/logger/CategoryView.java
@@ -6,6 +6,7 @@ import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.ProvidesKey;
 import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.jboss.as.console.client.Console;
@@ -40,8 +41,9 @@ public class CategoryView {
 
     public CategoryView(LoggerPresenter presenter) {
         this.presenter = presenter;
-        this.table = new DefaultCellTable(5);
-        this.dataProvider = new ListDataProvider<Property>();
+        ProvidesKey<Property> providesKey = Property::getName;
+        this.table = new DefaultCellTable<>(5, providesKey);
+        this.dataProvider = new ListDataProvider<>(providesKey);
         this.dataProvider.addDataDisplay(table);
     }
 
@@ -149,8 +151,8 @@ public class CategoryView {
     }
 
     public void setData(List<Property> data) {
-        selectionModel.clear();
         dataProvider.setList(data);
         table.selectDefaultEntity();
+        SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/standalone/deploymentscanner/DeploymentScannerView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/standalone/deploymentscanner/DeploymentScannerView.java
@@ -27,6 +27,7 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.ProvidesKey;
+import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import com.google.inject.Inject;
 import org.jboss.as.console.client.Console;
@@ -167,6 +168,7 @@ public class DeploymentScannerView extends SuspendableViewImpl implements Deploy
             selectionModel.clear();
         } else {
             table.selectDefaultEntity();
+            SelectionChangeEvent.fire(selectionModel); // updates ModelNodeForm's editedEntity with current value
         }
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-910
https://issues.jboss.org/browse/JBEAP-1504

Fixed couple of views so that selection in a table doesn't reset to the first row after editing.

Most times I just removed ```selectionModel.clear()``` in ```update()``` methods and added ```SelectionChangeEvent.fire(selectionModel)``` which triggers ```form.edit(<updated instance>)```.

I was testing replacing ```dataProvider.setList()``` with ```dataProvider.getList().addAll()``` like:

```
    protected void update(final List<Property> models) {
        dataProvider.getList().clear();
        dataProvider.getList().addAll(models);
        table.selectDefaultEntity();
        SelectionChangeEvent.fire(selectionModel);
    }
```

which helped to prevent selection resetting, but then table.selectDefaultEntity() was still seeing old values, so I couldn't update form with up-to-date instances easily.

I didn't find any negative effects of removing ```selectionModel.clear()```.