### PR TITLE
[BZ-1285357] Port-offset incorrectly displayed in JBoss EAP 6.4.4 adm…

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/domain/topology/TopologyPresenter.java
+++ b/gui/src/main/java/org/jboss/as/console/client/domain/topology/TopologyPresenter.java
@@ -179,7 +179,8 @@ public class TopologyPresenter extends Presenter<TopologyPresenter.MyView, Topol
             new Async<FunctionContext>(Footer.PROGRESS_ELEMENT).waterfall(new FunctionContext(), outcome,
                     new TopologyFunctions.HostsAndGroups(dispatcher),
                     new TopologyFunctions.ServerConfigs(dispatcher, beanFactory),
-                    new TopologyFunctions.RunningServerInstances(dispatcher));
+                    new TopologyFunctions.RunningServerInstances(dispatcher),
+                    new TopologyFunctions.EffectivePortOffset(dispatcher));
         }
     }
 


### PR DESCRIPTION
…in console

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1285357
Upstream not required as the read-only topology view that this issue affects is no longer present.  See HAL-993 for more details. 

HAL-993: https://issues.jboss.org/browse/HAL-993