### PR TITLE
[JBEAP-2246] Upgrade ballroom to 2.3.11

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
         <maven.min.version>3.1.0</maven.min.version>
         <auto-service.version>1.0-rc2</auto-service.version>
         <auto-common.version>0.3</auto-common.version>
-        <ballroom.version>2.3.11-SNAPSHOT</ballroom.version>
+        <ballroom.version>2.3.11</ballroom.version>
         <circuit.version>0.1.4</circuit.version>
         <freemarker.version>2.3.23</freemarker.version>
         <gin.version>2.1.2</gin.version>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-2246
Upgrade ballroom to 2.3.11 from 2.3.10 in hal core 2.8.x branch for EAP

need to merge hal/ballroom#3 and ballroom release 2.3.11 first

missing Acks in JIRA