### PR TITLE
BZ1289495 (Backport) Upgrade ballroom to 2.1.10.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
         <version.org.zanata.plugin>3.1.1</version.org.zanata.plugin>
         <version.maven.processor.plugin>3.1.0-beta1</version.maven.processor.plugin>
         <maven.min.version>3.1.0</maven.min.version>
-        <ballroom.version>2.1.9.Final</ballroom.version>
+        <ballroom.version>2.1.10.Final</ballroom.version>
         <circuit.version>0.0.8</circuit.version>
         <gin.version>2.1.2</gin.version>
         <guice.version>3.0</guice.version>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1289495 upgrade ballroom to 2.1.10.Final for EAP 6

need CDW Acks on bugzilla. and release ballroom 2.1.10.Final first