### PR TITLE
[HAL-903, JBEAP-1453] Cannot add discovery group to bridge attributes

### DIFF
--- a/dmr/src/main/java/org/jboss/dmr/client/ModelDescriptionConstants.java
+++ b/dmr/src/main/java/org/jboss/dmr/client/ModelDescriptionConstants.java
@@ -179,5 +179,6 @@ public class ModelDescriptionConstants {
     public static final String VALUE_TYPE = "value-type";
     public static final String WHOAMI = "whoami";
     public static final String WRITE_ATTRIBUTE_OPERATION = "write-attribute";
+    public static final String UNDEFINE_ATTRIBUTE_OPERATION = "undefine-attribute";
 }
 

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/activemq/connections/MsgConnectionsPresenter.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/activemq/connections/MsgConnectionsPresenter.java
@@ -42,6 +42,7 @@ import org.jboss.as.console.mbui.dmr.ResourceAddress;
 import org.jboss.as.console.mbui.widgets.AddResourceDialog;
 import org.jboss.as.console.spi.RequiredResources;
 import org.jboss.as.console.spi.SearchIndex;
+import org.jboss.ballroom.client.widgets.forms.FormItem;
 import org.jboss.ballroom.client.widgets.window.DefaultWindow;
 import org.jboss.dmr.client.ModelNode;
 import org.jboss.dmr.client.Property;
@@ -744,14 +745,24 @@ public class MsgConnectionsPresenter extends Presenter<MsgConnectionsPresenter.M
         addressNode.get(ADDRESS).set(address);
 
         ModelNode extra = null;
-        List<String> items = (List<String>) changeset.get("staticConnectors");
-        if (items != null) {
+        List<String> items = null;
+        Object staticConnectors = changeset.get("staticConnectors");
+        if (staticConnectors instanceof List) {
+            items = (List<String>) staticConnectors;
+        }
+        if (items != null && items.size() > 0) { // non-empty list
             extra = new ModelNode();
             extra.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
             extra.get(NAME).set("static-connectors");
             extra.get(ADDRESS).set(address);
             extra.get(VALUE).setEmptyList();
             for (String item : items) { extra.get(VALUE).add(item); }
+        } else if ((items != null && items.size() == 0)
+                || FormItem.VALUE_SEMANTICS.UNDEFINED.equals(staticConnectors)) { // empty list or "undefined"
+            extra = new ModelNode();
+            extra.get(OP).set(UNDEFINE_ATTRIBUTE_OPERATION);
+            extra.get(NAME).set("static-connectors");
+            extra.get(ADDRESS).set(address);
         }
 
         ModelNode operation = extra != null ?


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-903

When static-connectors is changed from previously non-empty to empty
value, operation step (undefine-attribute nor write-attibute) for this
field is not added to DMR.