### PR TITLE
[HAL-1017] JMSMetricPresenter always uses "default" as part of operation address even if name is changed.

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/runtime/jms/JMSMetricPresenter.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/runtime/jms/JMSMetricPresenter.java
@@ -173,7 +173,7 @@ public class JMSMetricPresenter extends CircuitPresenter<JMSMetricPresenter.MyVi
         ModelNode operation = new ModelNode();
         operation.get(ADDRESS).set(RuntimeBaseAddress.get());
         operation.get(ADDRESS).add("subsystem", "messaging");
-        operation.get(ADDRESS).add("hornetq-server", "default");
+        operation.get(ADDRESS).add("hornetq-server", currentServer);
         operation.get(ADDRESS).add("jms-queue", selectedQueue.getName());
 
         operation.get(OP).set(READ_RESOURCE_OPERATION);
@@ -209,7 +209,7 @@ public class JMSMetricPresenter extends CircuitPresenter<JMSMetricPresenter.MyVi
         ModelNode operation = new ModelNode();
         operation.get(ADDRESS).set(RuntimeBaseAddress.get());
         operation.get(ADDRESS).add("subsystem", "messaging");
-        operation.get(ADDRESS).add("hornetq-server", "default");
+        operation.get(ADDRESS).add("hornetq-server", currentServer);
         operation.get(ADDRESS).add("jms-topic", selectedTopic.getName());
 
         operation.get(OP).set(READ_RESOURCE_OPERATION);
@@ -266,7 +266,7 @@ public class JMSMetricPresenter extends CircuitPresenter<JMSMetricPresenter.MyVi
         ModelNode operation = new ModelNode();
         operation.get(ADDRESS).set(RuntimeBaseAddress.get());
         operation.get(ADDRESS).add("subsystem", "messaging");
-        operation.get(ADDRESS).add("hornetq-server", "default");
+        operation.get(ADDRESS).add("hornetq-server", currentServer);
         operation.get(ADDRESS).add("jms-queue", queue.getName());
 
         operation.get(OP).set("remove-messages");
@@ -294,7 +294,7 @@ public class JMSMetricPresenter extends CircuitPresenter<JMSMetricPresenter.MyVi
         ModelNode operation = new ModelNode();
         operation.get(ADDRESS).set(RuntimeBaseAddress.get());
         operation.get(ADDRESS).add("subsystem", "messaging");
-        operation.get(ADDRESS).add("hornetq-server", "default");
+        operation.get(ADDRESS).add("hornetq-server", currentServer);
         operation.get(ADDRESS).add("jms-topic", topic.getName());
 
         operation.get(OP).set("remove-messages");


### PR DESCRIPTION
upstream HAL issue: https://issues.jboss.org/browse/HAL-1017
upstream HAL master PR: #120

upstream JBEAP issue: https://issues.jboss.org/browse/JBEAP-2493
upstream HAL 2.8.x PR: https://github.com/hal/core/pull/121

https://bugzilla.redhat.com/show_bug.cgi?id=1293311 missing ack