### PR TITLE
[JBEAP-2006] When first editing PicketLink Federation key store wrong…

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/picketlink/SingletonEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/picketlink/SingletonEditor.java
@@ -101,6 +101,6 @@ abstract class SingletonEditor implements IsWidget {
 
     void reset() {
         formAssets.getForm().clearValues();
-        formAssets.getForm().edit(new ModelNode());
+        formAssets.getForm().editTransient(new ModelNode());
     }
 }


### PR DESCRIPTION
… string is saved for mandatory attributes where user doesn't enter value

https://issues.jboss.org/browse/JBEAP-2006

SingletonEditor in Picketlink subsystem administration was not validating input IF the input was new entity. 

* Validation gets triggered only if ModelNodeForm.editedEntity is null or the field is modified: https://github.com/hal/ballroom/blob/17c7181aa8fb7312da20cfc065cdcb566bc70dc8/widgets/src/main/java/org/jboss/ballroom/client/widgets/forms/AbstractForm.java#L103
* SingletonEditor sets the editedEntity to empty ModelNode in this case, breaking the condition above.
* At the same time, form.edit() must be called because it makes the "Edit" button appear.
* Not sure about the original purpose of form.editTransient(), but it seems to fit this situation perfectly - "Edit" button appears and the validation is triggered.