### PR TITLE
[JBEAP-3648] instead of showing bullet range, it's better to display actual value for current bar.

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/runtime/charts/BulletGraphView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/runtime/charts/BulletGraphView.java
@@ -381,7 +381,7 @@ public class BulletGraphView implements Sampler {
                     public String f(JsArgs args) {
                         Bullet d = args.getObject(0);
                         double measures = d.measures[0];
-                        return measures > 0.00 ? String.valueOf(Double.valueOf(d.ranges[0]).longValue()) : "";
+                        return measures > 0.00 ? String.valueOf(measures) : "";
                     }
                 });
 


### PR DESCRIPTION
fix issue reported in https://issues.jboss.org/browse/JBEAP-3648

upstream HAL issue: https://issues.jboss.org/browse/HAL-1055
upstream master branch PR: https://github.com/hal/core/pull/150
