### PR TITLE
HAL-972 - Replace deployment shouldn't allow to specify name and runtime-name

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/v3/deployment/DomainDeploymentFinder.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/deployment/DomainDeploymentFinder.java
@@ -24,7 +24,6 @@ package org.jboss.as.console.client.v3.deployment;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -37,13 +36,12 @@ import com.gwtplatform.mvp.client.proxy.PlaceManager;
 import com.gwtplatform.mvp.client.proxy.ProxyPlace;
 import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
 import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
+
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.core.BootstrapContext;
 import org.jboss.as.console.client.core.Footer;
 import org.jboss.as.console.client.core.Header;
 import org.jboss.as.console.client.core.NameTokens;
-import org.jboss.as.console.client.core.UIConstants;
-import org.jboss.as.console.client.core.UIMessages;
 import org.jboss.as.console.client.domain.model.ServerGroupRecord;
 import org.jboss.as.console.client.domain.topology.TopologyFunctions;
 import org.jboss.as.console.client.shared.BeanFactory;
@@ -78,7 +76,9 @@ import org.jboss.gwt.flow.client.Outcome;
 import org.useware.kernel.gui.behaviour.StatementContext;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.jboss.as.console.spi.OperationMode.Mode.DOMAIN;
@@ -335,8 +335,8 @@ public class DomainDeploymentFinder
                 Console.MESSAGES.contentFailedToUnassignFromServerGroups(content.getName())));
     }
 
-    public void launchReplaceContentWizard() {
-        replaceWizard.open();
+    public void launchReplaceContentWizard(Content content) {
+        replaceWizard.open(content);
     }
 
     public void removeContent(final Content content, boolean unmanaged) {

--- a/gui/src/main/java/org/jboss/as/console/client/v3/deployment/DomainDeploymentFinderView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/deployment/DomainDeploymentFinderView.java
@@ -23,7 +23,6 @@ package org.jboss.as.console.client.v3.deployment;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -38,8 +37,6 @@ import com.gwtplatform.mvp.client.proxy.PlaceManager;
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.core.NameTokens;
 import org.jboss.as.console.client.core.SuspendableViewImpl;
-import org.jboss.as.console.client.core.UIConstants;
-import org.jboss.as.console.client.core.UIMessages;
 import org.jboss.as.console.client.domain.model.ServerGroupRecord;
 import org.jboss.as.console.client.domain.model.SimpleCallback;
 import org.jboss.as.console.client.preview.PreviewContent;
@@ -273,7 +270,7 @@ public class DomainDeploymentFinderView extends SuspendableViewImpl implements D
                         .setOperationAddress("/deployment=*", "add"),
                 new MenuDelegate<Content>(Console.CONSTANTS.unassign(), item -> presenter.launchUnassignContentDialog(item), Operation)
                         .setOperationAddress("/deployment=*", "remove"),
-                new MenuDelegate<>(Console.CONSTANTS.common_label_replace(), item -> presenter.launchReplaceContentWizard(), Operation),
+                new MenuDelegate<>(Console.CONSTANTS.common_label_replace(), item -> presenter.launchReplaceContentWizard(item), Operation),
                 new MenuDelegate<Content>(Console.CONSTANTS.common_label_delete(), item -> {
                     if (!item.getAssignments().isEmpty()) {
                         String serverGroups = "\t- " + Joiner.on("\n\t- ").join(

--- a/gui/src/main/java/org/jboss/as/console/client/v3/deployment/StandaloneDeploymentFinder.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/deployment/StandaloneDeploymentFinder.java
@@ -21,17 +21,19 @@
  */
 package org.jboss.as.console.client.v3.deployment;
 
-import com.google.gwt.event.shared.GwtEvent;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.inject.Inject;
-import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.mvp.client.annotations.ContentSlot;
-import com.gwtplatform.mvp.client.annotations.NameToken;
-import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
-import com.gwtplatform.mvp.client.proxy.PlaceManager;
-import com.gwtplatform.mvp.client.proxy.ProxyPlace;
-import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
-import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
+import static org.jboss.as.console.spi.OperationMode.Mode.STANDALONE;
+import static org.jboss.dmr.client.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.dmr.client.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.dmr.client.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
+import static org.jboss.dmr.client.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.dmr.client.ModelDescriptionConstants.REMOVE;
+import static org.jboss.dmr.client.ModelDescriptionConstants.RESULT;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.core.BootstrapContext;
 import org.jboss.as.console.client.core.Header;
@@ -55,11 +57,17 @@ import org.jboss.dmr.client.dispatch.impl.DMRAction;
 import org.jboss.dmr.client.dispatch.impl.DMRResponse;
 import org.jboss.dmr.client.dispatch.impl.UploadHandler;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.jboss.as.console.spi.OperationMode.Mode.STANDALONE;
-import static org.jboss.dmr.client.ModelDescriptionConstants.*;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.inject.Inject;
+import com.google.web.bindery.event.shared.EventBus;
+import com.gwtplatform.mvp.client.annotations.ContentSlot;
+import com.gwtplatform.mvp.client.annotations.NameToken;
+import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
+import com.gwtplatform.mvp.client.proxy.PlaceManager;
+import com.gwtplatform.mvp.client.proxy.ProxyPlace;
+import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
+import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 /**
  * @author Harald Pehl
@@ -171,8 +179,8 @@ public class StandaloneDeploymentFinder
         }
     }
 
-    public void launchReplaceDeploymentWizard() {
-        replaceWizard.open();
+    public void launchReplaceDeploymentWizard(Content content) {
+        replaceWizard.open(content);
     }
 
     public void verifyEnableDisableDeployment(final Deployment deployment) {

--- a/gui/src/main/java/org/jboss/as/console/client/v3/deployment/StandaloneDeploymentFinderView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/deployment/StandaloneDeploymentFinderView.java
@@ -125,7 +125,7 @@ public class StandaloneDeploymentFinderView extends SuspendableViewImpl
         deploymentColumn.setMenuItems(
                 new MenuDelegate<>(Console.CONSTANTS.common_label_view(), item -> presenter.showDetails(), Navigation),
                 enableDisableDelegate,
-                new MenuDelegate<>(Console.CONSTANTS.common_label_replace(), item -> presenter.launchReplaceDeploymentWizard(), Operation),
+                new MenuDelegate<>(Console.CONSTANTS.common_label_replace(), item -> presenter.launchReplaceDeploymentWizard(item), Operation),
                 new MenuDelegate<>(Console.CONSTANTS.common_label_delete(), item -> presenter.verifyRemoveDeployment(item), Operation)
         );
 

--- a/gui/src/main/java/org/jboss/as/console/client/v3/deployment/wizard/ReplaceDeploymentWizard.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/deployment/wizard/ReplaceDeploymentWizard.java
@@ -21,27 +21,29 @@
  */
 package org.jboss.as.console.client.v3.deployment.wizard;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.ui.PopupPanel;
+import static org.jboss.as.console.client.v3.deployment.wizard.State.UPLOAD;
+
+import java.util.EnumSet;
+
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.core.BootstrapContext;
 import org.jboss.as.console.client.core.Footer;
-import org.jboss.as.console.client.core.UIConstants;
 import org.jboss.as.console.client.shared.BeanFactory;
 import org.jboss.as.console.client.shared.flow.FunctionContext;
+import org.jboss.as.console.client.v3.deployment.Content;
 import org.jboss.as.console.client.v3.deployment.DeploymentFunctions;
 import org.jboss.ballroom.client.widgets.window.Feedback;
 import org.jboss.dmr.client.dispatch.DispatchAsync;
 import org.jboss.gwt.flow.client.Async;
 
-import java.util.EnumSet;
-
-import static org.jboss.as.console.client.v3.deployment.wizard.State.UPLOAD;
+import com.google.gwt.user.client.ui.PopupPanel;
 
 /**
  * @author Harald Pehl
  */
 public abstract class ReplaceDeploymentWizard extends DeploymentWizard {
+
+    private Content content;
 
     public ReplaceDeploymentWizard(BootstrapContext bootstrapContext, BeanFactory beanFactory,
             DispatchAsync dispatcher, FinishCallback onFinish) {
@@ -50,7 +52,8 @@ public abstract class ReplaceDeploymentWizard extends DeploymentWizard {
         addStep(UPLOAD, new UploadStep(this));
     }
 
-    public void open() {
+    public void open(Content content) {
+        this.content = content;
         super.open(Console.CONSTANTS.replaceDeployment());
     }
 
@@ -80,6 +83,10 @@ public abstract class ReplaceDeploymentWizard extends DeploymentWizard {
                 Console.CONSTANTS.common_label_plaseWait(),
                 Console.CONSTANTS.common_label_requestProcessed(), () -> {}
         );
+
+        // as it is as replace operation, the new upload name/runtime must preserve the actual deployment information.
+        context.upload.setName(content.getName());
+        context.upload.setRuntimeName(content.getRuntimeName());
 
         new Async<FunctionContext>(Footer.PROGRESS_ELEMENT).single(new FunctionContext(),
                 new DeploymentWizardOutcome(loading, context),


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-972
In fact, the replace operation, preserve the actual deployment name and runtime-name