### PR TITLE
[BZ-1319994] Patch Management doesn't show the "Latest Applied Patch" correctly

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/patching/PatchManager.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/patching/PatchManager.java
@@ -223,7 +223,7 @@ public class PatchManager {
             historyOp.get(OP).set("show-history");
             steps.add(historyOp);
 
-            ModelNode latestPatchOp = baseAddress();
+            ModelNode latestPatchOp = baseAddress(host);
             latestPatchOp.get(OP).set(READ_RESOURCE_OPERATION);
             latestPatchOp.get(INCLUDE_RUNTIME).set(true);
             steps.add(latestPatchOp);


### PR DESCRIPTION
Jira Upstream: https://issues.jboss.org/browse/HAL-1072
setting the proper host during patch info fetch operation.