### PR TITLE
[BZ-1319994] Patch Management doesn't show the "Latest Applied Patch" correctly

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/patching/PatchManager.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/patching/PatchManager.java
@@ -222,7 +222,7 @@ public class PatchManager {
             historyOp.get(OP).set("show-history");
             steps.add(historyOp);
 
-            ModelNode latestPatchOp = baseAddress();
+            ModelNode latestPatchOp = baseAddress(host);
             latestPatchOp.get(OP).set(READ_RESOURCE_OPERATION);
             latestPatchOp.get(INCLUDE_RUNTIME).set(true);
             steps.add(latestPatchOp);


### PR DESCRIPTION
BZ 6.4.z: https://bugzilla.redhat.com/show_bug.cgi?id=1319994
Upstream PR: https://github.com/hal/core/pull/185

setting the proper host during patch info fetch operation.