### PR TITLE
HAL-1054

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/domain/runtime/DomainRuntimeView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/domain/runtime/DomainRuntimeView.java
@@ -257,7 +257,7 @@ public class DomainRuntimeView extends SuspendableViewImpl implements DomainRunt
                 new ProvidesKey<Server>() {
                     @Override
                     public Object getKey(Server item) {
-                        return item.getName() + item.getHostName();
+                        return item.getName() + item.getHostName() + ":" + item.getServerState();
                     }
                 }, presenter.getProxy().getNameToken());
 
@@ -699,7 +699,19 @@ public class DomainRuntimeView extends SuspendableViewImpl implements DomainRunt
     @Override
     public void updateServerList(List<Server> serverModel) {
         columnManager.reduceColumnsTo(1);
-        serverColumn.updateFrom(serverModel, false);
+
+        Server oldServer = serverColumn.getSelectedItem();
+        Server newServer = null;
+
+        if (oldServer != null) {
+            for (Server s : serverModel) {
+                if (s.getName().equals(oldServer.getName())) {
+                    newServer = s;
+                    break;
+                }
+            }
+        }
+        serverColumn.updateFrom(serverModel, newServer);
         //previewCanvas.clear();
     }
 

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceFinderView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceFinderView.java
@@ -179,7 +179,7 @@ public class DataSourceFinderView extends SuspendableViewImpl implements DataSou
                 new ProvidesKey<DataSource>() {
                     @Override
                     public Object getKey(DataSource item) {
-                        return item.getName();
+                        return item.getName() + ":" + item.isEnabled();
                     }
                 }, presenter.getProxy().getNameToken())
         ;
@@ -470,12 +470,32 @@ public class DataSourceFinderView extends SuspendableViewImpl implements DataSou
 
     @Override
     public void updateDataSources(List<DataSource> list) {
-        datasources.updateFrom(list);
+        DataSource oldDs = datasources.getSelectedItem();
+        DataSource newDs = null;
+        if (oldDs != null) {
+            for (DataSource ds : list) {
+                if (ds.getName().equals(oldDs.getName())) {
+                    newDs = ds;
+                    break;
+                }
+            }
+        }
+        datasources.updateFrom(list, newDs);
     }
 
     @Override
     public void updateXADataSources(List<XADataSource> list) {
-        xadatasources.updateFrom(list);
+        XADataSource oldXADs = xadatasources.getSelectedItem();
+        XADataSource newXADs = null;
+        if (oldXADs != null) {
+            for (XADataSource xds : list) {
+                if (xds.getName().equals(oldXADs.getName())) {
+                    newXADs = xds;
+                    break;
+                }
+            }
+        }
+        xadatasources.updateFrom(list, newXADs);
     }
 
     @Override

--- a/gui/src/main/java/org/jboss/as/console/client/v3/deployment/ContentColumn.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/deployment/ContentColumn.java
@@ -61,7 +61,7 @@ public class ContentColumn extends FinderColumn<Content> {
                 new ProvidesKey<Content>() {
                     @Override
                     public Object getKey(final Content item) {
-                        return item.getName();
+                        return item.getName() + ":" + item.getAssignments().size();
                     }
                 },
                 NameTokens.DomainDeploymentFinder,

--- a/gui/src/main/java/org/jboss/as/console/client/v3/deployment/DomainDeploymentFinderView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/deployment/DomainDeploymentFinderView.java
@@ -131,7 +131,7 @@ public class DomainDeploymentFinderView extends SuspendableViewImpl implements D
                 new ProvidesKey<Assignment>() {
                     @Override
                     public Object getKey(final Assignment item) {
-                        return item.getName();
+                        return item.getName() + ":" + item.isEnabled();
                     }
                 },
                 NameTokens.DomainDeploymentFinder,
@@ -423,12 +423,32 @@ public class DomainDeploymentFinderView extends SuspendableViewImpl implements D
 
     @Override
     public void updateContentRepository(final Iterable<Content> content) {
-        contentColumn.updateFrom(Lists.newArrayList(content));
+        Content oldContent = contentColumn.getSelectedItem();
+        Content newContent = null;
+
+        if (oldContent != null) {
+            for (Content c : content) {
+                if (c.getName().equals(oldContent.getName())) {
+                    newContent = c;
+                }
+            }
+        }
+        contentColumn.updateFrom(Lists.newArrayList(content), newContent);
     }
 
     @Override
     public void updateUnassigned(final Iterable<Content> unassigned) {
-        unassignedColumn.updateFrom(Lists.newArrayList(unassigned));
+        Content oldContent = unassignedColumn.getSelectedItem();
+        Content newContent = null;
+
+        if (oldContent != null) {
+            for (Content c : unassigned) {
+                if (c.getName().equals(oldContent.getName()) && !c.getAssignments().isEmpty()) {
+                    newContent = c;
+                }
+            }
+        }
+        unassignedColumn.updateFrom(Lists.newArrayList(unassigned), newContent);
     }
 
     @Override
@@ -438,6 +458,16 @@ public class DomainDeploymentFinderView extends SuspendableViewImpl implements D
 
     @Override
     public void updateAssignments(final Iterable<Assignment> assignments) {
-        assignmentColumn.updateFrom(Lists.newArrayList(assignments));
+        Assignment oldAssignment = assignmentColumn.getSelectedItem();
+        Assignment newAssignment = null;
+
+        if (oldAssignment != null) {
+            for (Assignment a : assignments) {
+                if (a.getName().equals(oldAssignment.getName())) {
+                    newAssignment = a;
+                }
+            }
+        }
+        assignmentColumn.updateFrom(Lists.newArrayList(assignments), newAssignment);
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/v3/deployment/StandaloneDeploymentFinderView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/deployment/StandaloneDeploymentFinderView.java
@@ -180,7 +180,17 @@ public class StandaloneDeploymentFinderView extends SuspendableViewImpl
 
     @Override
     public void updateDeployments(Iterable<Deployment> deployments) {
-        deploymentColumn.updateFrom(Lists.newArrayList(deployments));
+        Deployment oldDeployment = deploymentColumn.getSelectedItem();
+        Deployment newDeployment = null;
+
+        if (oldDeployment != null) {
+            for (Deployment d : deployments) {
+                if (d.getName().equals(oldDeployment.getName())) {
+                    newDeployment = d;
+                }
+            }
+        }
+        deploymentColumn.updateFrom(Lists.newArrayList(deployments), newDeployment);
     }
 
 

--- a/gui/src/main/java/org/jboss/as/console/client/widgets/nav/v3/FinderColumn.java
+++ b/gui/src/main/java/org/jboss/as/console/client/widgets/nav/v3/FinderColumn.java
@@ -843,6 +843,24 @@ public class FinderColumn<T> implements SecurityContextAware {
         }*/
     }
 
+    public void updateFrom(final List<T> records, T selectedItem) {
+        if (selectedItem == null) {
+            updateFrom(records);
+            return;
+        }
+
+        if(filter!=null) filter.clear();
+
+        selectionModel.setSelected(selectedItem, true);
+        triggerPreviewEvent();
+
+        dataProvider.setList(records);
+
+        if(!plain) {
+            updateTitle();
+        }
+    }
+
     /**
      * renderer for the column content
      * @param <T>

--- a/gui/src/main/java/org/jboss/as/console/public/lab.css
+++ b/gui/src/main/java/org/jboss/as/console/public/lab.css
@@ -443,7 +443,7 @@
     padding-right: 5px;
 }
 
-.nav-hover .cellTableSelectedRowCell .nav-menu {
+.cellTableSelectedRowCell .nav-menu {
     display: inherit;
 }
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/HAL-1054

The change in getKey is to ensure onSelectionChange is fired (otherwise reselecting the same item doesn't work). As for the CSS change the last action that happens is the cells being rerendered so the `nav-hover` class is missing; as far as I understand from [HAL-738](https://issues.jboss.org/browse/HAL-738) a cell being selected is enough to allow the menu to be visible. 