### PR TITLE
[JBEAP-5053 / HAL-1127] naming binding cannot be removed

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/v3/dmr/AddressTemplate.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/dmr/AddressTemplate.java
@@ -88,7 +88,7 @@ public class AddressTemplate {
         }
 
         String normalized = template.startsWith(OPT) ? template.substring(5) : template;
-        StringTokenizer tok = new StringTokenizer(normalized, "/");
+        StringTokenizer tok = new StringTokenizer(normalized, "/", '\\');
         while (tok.hasMoreTokens()) {
             String nextToken = tok.nextToken();
             if (nextToken.contains("=")) {
@@ -397,15 +397,17 @@ public class AddressTemplate {
 
     private static class StringTokenizer {
         private final String delim;
+        private final char escapeChar;
         private final String s;
         private final int len;
 
         private int pos;
         private String next;
 
-        StringTokenizer(String s, String delim) {
+        StringTokenizer(String s, String delim, char escapeChar) {
             this.s = s;
             this.delim = delim;
+            this.escapeChar = escapeChar;
             len = s.length();
         }
 
@@ -433,6 +435,9 @@ public class AddressTemplate {
 
             int p0 = pos++;
             while (pos < len && delim.indexOf(s.charAt(pos)) == -1) {
+                if (s.charAt(pos) == escapeChar) {
+                    pos++;
+                }
                 pos++;
             }
 

--- a/gui/src/main/java/org/jboss/as/console/mbui/widgets/AddressUtils.java
+++ b/gui/src/main/java/org/jboss/as/console/mbui/widgets/AddressUtils.java
@@ -86,11 +86,11 @@ public class AddressUtils {
 
             if(i==tuples.size()-1)
                 if(fq)
-                    sb.append(tuple.getValue().asString());
+                    sb.append(escapeValue(tuple.getValue().asString()));
                 else
                     sb.append("*");
             else
-                sb.append(tuple.getValue().asString());
+                sb.append(escapeValue(tuple.getValue().asString()));
 
             i++;
         }
@@ -111,11 +111,11 @@ public class AddressUtils {
 
             if(i==tuples.size()-1)
                 if(fq)
-                    sb.append(tuple.getValue().asString());
+                    sb.append(escapeValue(tuple.getValue().asString()));
                 else
                     sb.append("*");
             else
-                sb.append(tuple.getValue().asString());
+                sb.append(escapeValue(tuple.getValue().asString()));
 
             i++;
         }
@@ -125,4 +125,11 @@ public class AddressUtils {
 
         return sb.toString();
     }
+
+    private static String escapeValue(String addressSegment) {
+        return addressSegment
+                .replace("/", "\\/")
+                .replace(":", "\\:");
+    }
+
 }

--- a/gui/src/test/java/org/jboss/as/console/client/v3/dmr/AddressTemplateTest.java
+++ b/gui/src/test/java/org/jboss/as/console/client/v3/dmr/AddressTemplateTest.java
@@ -43,6 +43,13 @@ public class AddressTemplateTest {
     }
 
     @Test
+    public void escaping() {
+        AddressTemplate at = AddressTemplate.of("a=b/c=java\\:\\/d");
+        assertEquals(2, at.getNumTokens());
+        assertEquals("a=b/c=java\\:\\/d", at.getTemplate());
+    }
+
+    @Test
     public void optional() {
         AddressTemplate at = AddressTemplate.of("a=b");
         assertFalse(at.isOptional());

--- a/gui/src/test/java/org/jboss/as/console/mbui/widgets/AddressUtilsTest.java
+++ b/gui/src/test/java/org/jboss/as/console/mbui/widgets/AddressUtilsTest.java
@@ -1,0 +1,52 @@
+package org.jboss.as.console.mbui.widgets;
+
+import org.jboss.dmr.client.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Tomas Hofman (thofman@redhat.com)
+ */
+public class AddressUtilsTest {
+
+    @Test
+    public void testToString() {
+        ModelNode address = new ModelNode();
+        address.add("subsystem", "test");
+        address.add("resource", "name");
+
+        String s = AddressUtils.toString(address, true);
+        Assert.assertEquals("subsystem=test/resource=name", s);
+    }
+
+    @Test
+    public void testToStringValueContainsSlash() {
+        ModelNode address = new ModelNode();
+        address.add("subsystem", "test");
+        address.add("resource", "java:/global/a");
+
+        String s = AddressUtils.toString(address, true);
+        Assert.assertEquals("subsystem=test/resource=java\\:\\/global\\/a", s);
+    }
+
+    @Test
+    public void testAsKey() {
+        ModelNode address = new ModelNode();
+        address.add("subsystem", "test");
+        address.add("resource", "name");
+
+        String s = AddressUtils.asKey(address, true);
+        Assert.assertEquals("subsystem=test/resource=name", s);
+    }
+
+    @Test
+    public void testAsKeyValueContainsSlash() {
+        ModelNode address = new ModelNode();
+        address.add("subsystem", "test");
+        address.add("resource", "java:/global/a");
+
+        String s = AddressUtils.asKey(address, true);
+        Assert.assertEquals("subsystem=test/resource=java\\:\\/global\\/a", s);
+    }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-5053
https://issues.jboss.org/browse/HAL-1127

Upstream PR: https://github.com/hal/core/pull/244

Problem was that binding address was converted by `AddressUtils#toString()` to string "/subsystem=naming/binding=java:/global/a" and that was parsed by `AddressTemplate` to tokens

```
subsystem=naming
binding=java:
global
a
```

instead of

```
subsystem=naming
binding=java:/global/a
```

which lead to failure.

Fixed by:
- making `AddressUtils#toString(ModelNode address)` escape '/' characters in Property values,
- making `AddressTemplate.StringTokenizer` understand escaping.
