### PR TITLE
[JBEAP-5051] Remoting subsystem - outbound connections - bad text in tab next to attributes

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/remoting/ui/ConnectionEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/remoting/ui/ConnectionEditor.java
@@ -75,7 +75,7 @@ class ConnectionEditor extends RemotingEditor {
                 .setMasterTools(tools())
                 .setMaster(Console.MESSAGES.available(title), table())
                 .addDetail(Console.CONSTANTS.common_label_attributes(), formPanel())
-                .addDetail(Console.CONSTANTS.properties_global_desc(), propertyEditor().asWidget());
+                .addDetail(Console.CONSTANTS.common_label_properties(), propertyEditor().asWidget());
         return layoutBuilder.build();
     }
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-5051
Upstream issue: https://issues.jboss.org/browse/HAL-1021
Upstream PR: https://github.com/hal/core/pull/147