### PR TITLE
[HAL-1134] One-off patches overridden by CPs should be marked as such

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/core/UIConstants.java
+++ b/gui/src/main/java/org/jboss/as/console/client/core/UIConstants.java
@@ -358,6 +358,7 @@ public interface UIConstants extends Constants {
     String patch_manager_error_title();
     String patch_manager_error();
     String patch_manager_hide_details();
+    String patch_manager_in_effect();
     String patch_manager_latest();
     String patch_manager_patch_details();
     String patch_manager_possible_actions();

--- a/gui/src/main/java/org/jboss/as/console/client/core/UIConstants.properties
+++ b/gui/src/main/java/org/jboss/as/console/client/core/UIConstants.properties
@@ -327,6 +327,7 @@ patch_manager_desc_community=To apply a patch, you must first download a patch f
 patch_manager_error=Cannot read patch status
 patch_manager_error_title=Error
 patch_manager_hide_details=Hide error details
+patch_manager_in_effect=In Effect?
 patch_manager_latest=Latest Applied Patch
 patch_manager_patch_details=Patch Details
 patch_manager_possible_actions=Possible actions

--- a/gui/src/main/java/org/jboss/as/console/client/shared/patching/PatchInfo.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/patching/PatchInfo.java
@@ -50,4 +50,7 @@ public interface PatchInfo { //@formatter:off
 
     String getLink();
     void setLink(String link);
+
+    Boolean isInEffect();
+    void setInEffect(Boolean isInEffect);
 } //@formatter:on

--- a/gui/src/main/java/org/jboss/as/console/client/shared/patching/PatchManager.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/patching/PatchManager.java
@@ -21,6 +21,7 @@ package org.jboss.as.console.client.shared.patching;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.FileUpload;
 import com.google.inject.Inject;
+import org.apache.xpath.operations.Bool;
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.core.BootstrapContext;
 import org.jboss.as.console.client.shared.BeanFactory;
@@ -40,8 +41,10 @@ import org.jboss.dmr.client.Property;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import static org.jboss.as.console.client.shared.patching.Patches.STANDALONE_HOST;
 import static org.jboss.dmr.client.ModelDescriptionConstants.*;
@@ -180,7 +183,7 @@ public class PatchManager {
         });
     }
 
-    private PatchInfo historyToPatchInfo(final String identity, final ModelNode node) {
+    private PatchInfo historyToPatchInfo(final String identity, final ModelNode node, Boolean inEffect) {
         PatchInfo patchInfo = beanFactory.patchInfo().as();
         patchInfo.setId(node.get("patch-id").asString());
         patchInfo.setType(node.get("type").asString());
@@ -189,6 +192,7 @@ public class PatchManager {
         patchInfo.setIdentityVersion("");
         patchInfo.setDescription("");
         patchInfo.setLink("");
+        patchInfo.setInEffect(inEffect);
         return patchInfo;
     }
 
@@ -234,6 +238,7 @@ public class PatchManager {
          final ModelNode readResourceOperation = baseAddress(host);
          readResourceOperation.get(OP).set(READ_RESOURCE_OPERATION);
          readResourceOperation.get(INCLUDE_RUNTIME).set(true);
+         readResourceOperation.get(RECURSIVE).set(true);
          dispatcher.execute(new DMRAction(readResourceOperation), new AsyncCallback<DMRResponse>() {
 
             public void onFailure(Throwable caught) {
@@ -269,12 +274,13 @@ public class PatchManager {
 
                 //read patch streams and issue comp command to read
                 //patch list per stream.
-                final String[] patchStreams = sort(readResult.get("patch-stream").asPropertyList());
+                final ModelNode patchStreams = readResult.get("patch-stream");
+                final String[] patchStreamIDs = sort(patchStreams.asPropertyList());
                 final ModelNode comp = new ModelNode();
                 comp.get(ADDRESS).setEmptyList();
                 comp.get(OP).set(COMPOSITE);
                 List<ModelNode> steps = new LinkedList<ModelNode>();
-                for(String stream:patchStreams){
+                for(String stream:patchStreamIDs){
                     final ModelNode steppedOp = baseAddressForStream(host,stream);
                     steppedOp.get(OP).set("show-history");
                     steppedOp.get("include-runtime").set(true);
@@ -291,10 +297,16 @@ public class PatchManager {
 
                     public void onSuccess(DMRResponse result) {
                         final ModelNode compResult = result.get().get(RESULT);
-                        for(int index = 0; index < patchStreams.length; index++){
+                        for (int index = 0; index < patchStreamIDs.length; index++) {
+                            String streamId = patchStreamIDs[index];
+                            ModelNode patchStream = patchStreams.get(streamId);
+                            String cumulativePatchId = patchStream.get("cumulative-patch-id").asString();
+                            Set<String> patchesInEffect = stringListToSet(patchStream.get("patches").asList());
                             List<ModelNode> streamPatches = compResult.get("step-"+(index+1)).get(RESULT).asList();
-                            for(ModelNode patch:streamPatches){
-                                patches.add(historyToPatchInfo(patchStreams[index],patch));
+                            for (ModelNode patch: streamPatches) {
+                                String patchId = patch.get("patch-id").asString();
+                                boolean inEffect = patchesInEffect.contains(patchId) || patchId.equals(cumulativePatchId);
+                                patches.add(historyToPatchInfo(streamId, patch, inEffect));
                             }
                         }
                         // this should be done here because setLatestId is checked against the registered patches.
@@ -323,6 +335,14 @@ public class PatchManager {
             }
             Arrays.sort(streams);
             return streams;
+        }
+
+        private Set<String> stringListToSet(List<ModelNode> list) {
+            final Set<String> set  = new HashSet<>();
+            for (ModelNode node: list) {
+                set.add(node.asString());
+            }
+            return set;
         }
     }
 }

--- a/gui/src/main/java/org/jboss/as/console/client/shared/patching/ui/PatchInfoTable.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/patching/ui/PatchInfoTable.java
@@ -107,10 +107,17 @@ public class PatchInfoTable implements IsWidget, PatchManagementElementId {
                 return record.getType();
             }
         };
+        TextColumn<PatchInfo> inEffectColumn = new TextColumn<PatchInfo>() {
+            @Override
+            public String getValue(PatchInfo record) {
+                return record.isInEffect() ? "true" : "false";
+            }
+        };
         table.addColumn(idColumn, "ID");
         table.addColumn(patchStreamColumn, Console.CONSTANTS.common_label_patch_stream());
         table.addColumn(dateColumn, Console.CONSTANTS.common_label_date());
         table.addColumn(typeColumn, Console.CONSTANTS.common_label_type());
+        table.addColumn(inEffectColumn, Console.CONSTANTS.patch_manager_in_effect());
 
         DefaultPager pager = new DefaultPager();
         pager.getElement().setId(asId(PREFIX, getClass(), "_Pager"));


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-5004
https://issues.jboss.org/browse/HAL-1134

Adding "In effect?" column to PatchInfoTable to indicate if a patch was overwritten by newer cumulative patch.