### PR TITLE
[BZ-1352049] Security context of propertyEditor in ServerGroupView is never changed

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/domain/groups/ServerGroupView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/domain/groups/ServerGroupView.java
@@ -177,7 +177,6 @@ public class ServerGroupView extends SuspendableViewImpl implements ServerGroupP
         });
 
         propertyEditor = new PropertyEditor(presenter, true);
-        propertyEditor.setOperationAddress("/server-group={selected.entity}/system-property=*", "add");
 
         // --------------------
 


### PR DESCRIPTION
EAP 6 BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1352049

No upstream change required, already fixed in 2.8.x/master.

This is prerequisite for https://bugzilla.redhat.com/show_bug.cgi?id=1343591.