### PR TITLE
[HAL-1143] "JVM Options" should not be marked with asterisk

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/jvm/JvmEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/jvm/JvmEditor.java
@@ -156,7 +156,12 @@ public class JvmEditor {
         HeapBoxItem maxPermgen = new HeapBoxItem("maxPermgen", "Max Permgen Size", false);
         HeapBoxItem permgen = new HeapBoxItem("permgen", "Permgen Size", false);
 
-        options = new ListItem("options", "JVM Options");
+        options = new ListItem("options", "JVM Options") {
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        };
 
         form.setFields(nameItem, heapItem, maxHeapItem, permgen, maxPermgen, options);
         form.setEnabled(false);


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-1143