### PR TITLE
HAL-1116 Expose stats for transaction System Rollbacks and Average Commit Time in the GUI

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/runtime/tx/GeneralView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/runtime/tx/GeneralView.java
@@ -51,6 +51,7 @@ class GeneralView implements IsWidget {
 
         columns = new Column[]{
                 new TextColumn("Status", "OFF"),
+                new NumberColumn("average-commit-time", "Average Commit Time"),
                 new NumberColumn("number-of-inflight-transactions", "Inflight Transactions"),
                 new NumberColumn("number-of-nested-transactions", "Nested Transactions")
         };

--- a/gui/src/main/java/org/jboss/as/console/client/shared/runtime/tx/TXRollbackView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/runtime/tx/TXRollbackView.java
@@ -34,7 +34,7 @@ class TXRollbackView implements Sampler {
     private Widget displayStrategy() {
 
         Column[] cols = new Column[] {
-                new NumberColumn("number-of-total-rollbacks","Total Failures").setBaseline(true),
+                new NumberColumn("number-of-system-rollbacks","System Failures"),
                 new NumberColumn("number-of-application-rollbacks","Application Failures"),
                 new NumberColumn("number-of-resource-rollbacks","Resource Failures")
         };


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-1116
Also removed the attribute number-of-total-rollbacks because it is missing from DMR result.