### PR TITLE
HAL-1167 - Display datasource runtime attributes

### DIFF
--- a/dmr/src/main/java/org/jboss/dmr/client/ModelDescriptionConstants.java
+++ b/dmr/src/main/java/org/jboss/dmr/client/ModelDescriptionConstants.java
@@ -161,6 +161,7 @@ public class ModelDescriptionConstants {
     public static final String ROLLING_TO_SERVERS = "rolling-to-servers";
     public static final String ROLLOUT_PLAN = "rollout-plan";
     public static final String RUNTIME_NAME = "runtime-name";
+    public static final String RUNTIME_ONLY = "runtime-only";
     public static final String RUNNING_SERVER = "server";
     public static final String SCHEMA_LOCATION = "schema-location";
     public static final String SCHEMA_LOCATIONS = "schema-locations";

--- a/gui/src/main/java/org/jboss/as/console/client/core/UIConstants.java
+++ b/gui/src/main/java/org/jboss/as/console/client/core/UIConstants.java
@@ -498,6 +498,7 @@ public interface UIConstants extends Constants {
     String subsys_jca_dataSources_desc();
     String subsys_jca_dataSources();
     String subsys_jca_dataSourcesXA();
+    String subsys_jca_pool_statistics_tab();
     String subsys_jca_err_prop_required();
     String subsys_jca_error_context_removal_desc();
     String subsys_jca_error_context_removal();

--- a/gui/src/main/java/org/jboss/as/console/client/core/UIConstants.properties
+++ b/gui/src/main/java/org/jboss/as/console/client/core/UIConstants.properties
@@ -465,6 +465,7 @@ subsys_jca_dataSource_verify=Test Connection
 subsys_jca_dataSource_xaprop_help=Properties to assign to the XADataSource implementation class.
 subsys_jca_dataSources=Datasources
 subsys_jca_dataSourcesXA=XA Datasources
+subsys_jca_pool_statistics_tab=Pool Statistics
 subsys_jca_dataSources_desc=JDBC datasource configurations.
 subsys_jca_datasource_error_load=Failed to load datasources and drivers.
 subsys_jca_err_prop_required=At least one XA property is required (i.e. url).

--- a/gui/src/main/java/org/jboss/as/console/client/shared/runtime/ds/DataSourceMetricView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/runtime/ds/DataSourceMetricView.java
@@ -1,13 +1,14 @@
 package org.jboss.as.console.client.shared.runtime.ds;
 
+import java.util.List;
+
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.Widget;
 import org.jboss.as.console.client.core.SuspendableViewImpl;
 import org.jboss.as.console.client.shared.runtime.Metric;
 import org.jboss.as.console.client.shared.subsys.jca.model.DataSource;
 import org.jboss.as.console.client.widgets.tabs.DefaultTabLayoutPanel;
-
-import java.util.List;
+import org.jboss.dmr.client.ModelNode;
 
 /**
  * @author Heiko Braun
@@ -60,11 +61,11 @@ public class DataSourceMetricView extends SuspendableViewImpl implements DataSou
     }
 
     @Override
-    public void setDSPoolMetric(Metric poolMetric, boolean isXA) {
+    public void setDSPoolMetric(ModelNode results, boolean isXA) {
         if(isXA)
-            xaMetrics.setDSPoolMetric(poolMetric);
+            xaMetrics.setDSPoolMetric(results);
         else
-            dsMetrics.setDSPoolMetric(poolMetric);
+            dsMetrics.setDSPoolMetric(results);
     }
 
     @Override

--- a/gui/src/main/java/org/jboss/as/console/client/v3/behaviour/SelectionAwareContext.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/behaviour/SelectionAwareContext.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.console.client.v3.behaviour;
+
+/**
+ * @author Claudio Miranda <claudio@redhat.com>
+ */
+public interface SelectionAwareContext {
+    
+    String getSelection();
+}

--- a/gui/src/main/java/org/jboss/as/console/client/v3/behaviour/SelectionFilteringStatementContext.java
+++ b/gui/src/main/java/org/jboss/as/console/client/v3/behaviour/SelectionFilteringStatementContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.console.client.v3.behaviour;
+
+import org.useware.kernel.gui.behaviour.FilteringStatementContext;
+import org.useware.kernel.gui.behaviour.StatementContext;
+
+/**
+ * @author Claudio Miranda <claudio@redhat.com>
+ */
+public class SelectionFilteringStatementContext extends FilteringStatementContext {
+
+    private String entityKey =  "selected.entity";
+
+    public SelectionFilteringStatementContext(final StatementContext delegate, final SelectionAwareContext viewEditor) {
+        this(null, delegate, viewEditor);
+    }
+    
+    public SelectionFilteringStatementContext(String entityKey, final StatementContext delegate, final SelectionAwareContext viewEditor) {
+        super(delegate, new Filter() {
+            @Override
+            public String filter(String key) {
+                if (entityKey.equals(key) && viewEditor.getSelection() != null) {
+                    return viewEditor.getSelection();
+                }
+                return "*";
+            }
+
+            @Override
+            public String[] filterTuple(String key) {
+                return null;
+            }
+        });
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-1167

the runtime-only=storage check is performed only when the matchingAddress returns false this cover the corner case of r-r-d for /subsystem=datasources/data-source=*/statistics=pool because the fix of WFCORE-1737 resolves the datasource=* wildcard
SelectionFilteringStatementContext is the general SelectionFilteringAwareContext, can be reused. Not used now, but added for later use.