### PR TITLE
Revert "[JBEAP-7404] Wrong dialog title when suspending server in managed domain"

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/domain/runtime/DomainRuntimePresenter.java
+++ b/gui/src/main/java/org/jboss/as/console/client/domain/runtime/DomainRuntimePresenter.java
@@ -332,7 +332,7 @@ public class DomainRuntimePresenter
     }
 
     public void onLaunchSuspendDialogue(Server server) {
-        window = new DefaultWindow("Suspend Server");
+        window = new DefaultWindow("Suspend Server Group");
         window.setWidth(480);
         window.setHeight(360);
         window.trapWidget(new ServerSuspendDialogue(this, server).asWidget());


### PR DESCRIPTION
Reverts hal/core#342. Merged this by accident into the 2.8.x branch