### PR TITLE
HAL-1255 - Configuration of singleton policy in singleton subsystem dissapears in Web Console

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/mbui/widgets/AddressUtils.java
+++ b/gui/src/main/java/org/jboss/as/console/mbui/widgets/AddressUtils.java
@@ -1,9 +1,9 @@
 package org.jboss.as.console.mbui.widgets;
 
+import java.util.List;
+
 import org.jboss.dmr.client.ModelNode;
 import org.jboss.dmr.client.Property;
-
-import java.util.List;
 
 /**
  * @author Heiko Braun
@@ -120,8 +120,8 @@ public class AddressUtils {
             i++;
         }
 
-        if(tuples.isEmpty())
-            sb.append("ROOT"); // better then empty string
+        //if(tuples.isEmpty())
+        //    sb.append("ROOT"); // better then empty string
 
         return sb.toString();
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-1255
Some small fix and enhancements:
* fix for ModelBrowser, when starts at ROOT node, use an empty string instead.
* fix to consider the org.wildfly.domain.profile capability