### PR TITLE
HAL-1281: journal-page-store-table attribute name fix.

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/activemq/ProviderView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/activemq/ProviderView.java
@@ -78,7 +78,7 @@ public class ProviderView implements MessagingAddress {
             "journal-messages-table",
             "journal-large-messages-table",
             "journal-bindings-table",
-            "journal-paging-table",
+            "journal-page-store-table",
             "create-journal-dir",
     };
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/HAL-1281