### PR TITLE
HAL-1293 Major and minor versions in datasource wizard are unnecessary

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/wizard/DriverStep.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/wizard/DriverStep.java
@@ -35,7 +35,6 @@ import org.jboss.as.console.client.v3.widgets.wizard.WizardStep;
 import org.jboss.as.console.client.widgets.ContentDescription;
 import org.jboss.ballroom.client.widgets.forms.Form;
 import org.jboss.ballroom.client.widgets.forms.FormValidation;
-import org.jboss.ballroom.client.widgets.forms.NumberBoxItem;
 import org.jboss.ballroom.client.widgets.forms.TextBoxItem;
 import org.jboss.ballroom.client.widgets.tables.DefaultCellTable;
 import org.jboss.ballroom.client.widgets.tables.DefaultPager;
@@ -69,16 +68,10 @@ class DriverStep<T extends DataSource> extends WizardStep<Context<T>, State> {
         TextBoxItem moduleName = new TextBoxItem("driverModuleName", "Module Name", true);
         TextBoxItem driverClass = new TextBoxItem("driverClass", "Driver Class", false);
         TextBoxItem xaDataSource = new TextBoxItem("xaDataSourceClass", "XA DataSource Class", false);
-        NumberBoxItem major = new NumberBoxItem("majorVersion", "Major Version") {{
-            setRequired(false);
-        }};
-        NumberBoxItem minor = new NumberBoxItem("minorVersion", "Minor Version") {{
-            setRequired(false);
-        }};
         if (context.xa) {
-            form.setFields(driverName, moduleName, driverClass, xaDataSource, major, minor);
+            form.setFields(driverName, moduleName, driverClass, xaDataSource);
         } else {
-            form.setFields(driverName, moduleName, driverClass, major, minor);
+            form.setFields(driverName, moduleName, driverClass);
         }
 
         FlowPanel formPanel = new FlowPanel();


### PR DESCRIPTION
Major and minor version fields aren't used for anything.

https://issues.jboss.org/browse/HAL-1293
https://issues.jboss.org/browse/JBEAP-8759