### PR TITLE
HAL-1265 - Not possible to create Elytron custom credetial security factory in standalone mode

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/ui/factory/CustomCredentialSecurityFactoryView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/ui/factory/CustomCredentialSecurityFactoryView.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.console.client.shared.subsys.elytron.ui.factory;
+
+import org.jboss.as.console.client.shared.subsys.elytron.ui.ElytronGenericResourceView;
+import org.jboss.as.console.client.v3.dmr.AddressTemplate;
+import org.jboss.as.console.client.v3.dmr.ResourceDescription;
+import org.jboss.ballroom.client.rbac.SecurityContext;
+import org.jboss.dmr.client.ModelNode;
+import org.jboss.gwt.circuit.Dispatcher;
+
+import static org.jboss.dmr.client.ModelDescriptionConstants.*;
+
+/**
+ * @author Claudio Miranda <claudio@redhat.com>
+ */
+public class CustomCredentialSecurityFactoryView extends ElytronGenericResourceView {
+
+    private ConfigurableSaslServerFactoryFilterEditor filterEditor;
+
+    public CustomCredentialSecurityFactoryView(final Dispatcher circuit,
+            final ResourceDescription resourceDescription,
+            final SecurityContext securityContext, final String title,
+            final AddressTemplate addressTemplate) {
+        super(circuit, resourceDescription, securityContext, title, addressTemplate);
+
+        // workaround for HAL-1265 - Not possible to create Elytron custom credetial security factory in standalone mode
+        // this workaround it to allow testing elytron subsystem in HAL, until it is fixed in the subsystem level
+        ModelNode moduleDesc = resourceDescription.get(OPERATIONS).get(ADD).get(REQUEST_PROPERTIES).get("module");
+        moduleDesc.get(REQUIRED).set(true);
+        moduleDesc.get(NILLABLE).set(false);
+
+        moduleDesc = resourceDescription.get(ATTRIBUTES).get("module");
+        moduleDesc.get(REQUIRED).set(true);
+        moduleDesc.get(NILLABLE).set(false);
+    }
+
+}

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/ui/factory/FactoryView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/ui/factory/FactoryView.java
@@ -39,7 +39,7 @@ public class FactoryView {
     private ElytronGenericResourceView aggregateSaslServerFactoryView;
     private ElytronGenericResourceView configurableHttpServerMechanismFactoryView;
     private ConfigurableSaslServerFactoryView configurableSaslServerFactoryView;
-    private ElytronGenericResourceView customCredentialSecurityFactoryView;
+    private CustomCredentialSecurityFactoryView customCredentialSecurityFactoryView;
     private GenericAuthenticationFactoryView httpAuthenticationFactoryView;
     private ElytronGenericResourceView kerberosSecurityFactoryView;
     private MechanismProviderFilteringSaslSserverFactoryView mechanismProviderFilteringSaslServerFactoryView;
@@ -100,7 +100,7 @@ public class FactoryView {
                 configurablesaslserverfactoryDescription, securityContext, "Configurable SASL Server",
                 ElytronStore.CONFIGURABLE_SASL_SERVER_FACTORY_ADDRESS);
 
-        customCredentialSecurityFactoryView = new ElytronGenericResourceView(circuit,
+        customCredentialSecurityFactoryView = new CustomCredentialSecurityFactoryView(circuit,
                 customcredentialsecurityfactoryDescription, securityContext, "Custom Credential Security",
                 ElytronStore.CUSTOM_CREDENTIAL_SECURITY_FACTORY_ADDRESS);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-1265
workaround to allow testing elytron subsystem in HAL, until it is fixed in the subsystem level.