### PR TITLE
HAL-1315 `enabling` input value is rewriten...

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/ui/factory/ConfigurableHttpServerMechanismFactoryFilterEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/ui/factory/ConfigurableHttpServerMechanismFactoryFilterEditor.java
@@ -131,6 +131,8 @@ public class ConfigurableHttpServerMechanismFactoryFilterEditor implements IsWid
                     .setSecurityContext(securityContext)
                     .build();
             addFormAssets.getForm().setFields(patternFilter, enabling);
+            // clear optional fields, `enabling` field was put in the default group above
+            addFormAssets.getForm().clearGroup(ModelNodeFormBuilder.OPTIONAL_FIELDS_GROUP);
             addFormAssets.getForm().setEnabled(true);
 
             DefaultWindow dialog = new DefaultWindow(Console.MESSAGES.newTitle("Pattern filter"));

--- a/gui/src/main/java/org/jboss/as/console/mbui/widgets/ModelNodeFormBuilder.java
+++ b/gui/src/main/java/org/jboss/as/console/mbui/widgets/ModelNodeFormBuilder.java
@@ -44,6 +44,8 @@ import static org.jboss.dmr.client.ModelDescriptionConstants.*;
  */
 public class ModelNodeFormBuilder {
 
+    public final static String OPTIONAL_FIELDS_GROUP = "Optional Fields";
+
     public interface FormItemFactory {
 
         FormItem create(Property attributeDescription);
@@ -623,7 +625,7 @@ public class ModelNodeFormBuilder {
             form.setFields(requiredItems.toArray(new FormItem[]{}));
 
             if (optionalItems.size() > 0) {
-                form.setFieldsInGroup("Optional Fields", new DisclosureGroupRenderer(),
+                form.setFieldsInGroup(OPTIONAL_FIELDS_GROUP, new DisclosureGroupRenderer(),
                         optionalItems.toArray(new FormItem[]{}));
             }
         }


### PR DESCRIPTION
...in Configurable HTTP Server Mechanism filter

* the form item was defined in both default and optional group, so the
value of default group item was rewritten

https://issues.jboss.org/browse/HAL-1315
https://issues.jboss.org/browse/JBEAP-9569

This depends on https://github.com/hal/ballroom/pull/19