### PR TITLE
HAL-1325 / HAL-1326 - two small fixes for ActiveMQ Bridge and Elytron security domain

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/activemq/connections/BridgesList.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/activemq/connections/BridgesList.java
@@ -118,7 +118,7 @@ public class BridgesList {
 
             @Override
             public void onCancel(final Object entity) {
-
+                defaultAttributes.getForm().cancel();
             }
         });
 
@@ -139,7 +139,7 @@ public class BridgesList {
 
             @Override
             public void onCancel(final Object entity) {
-
+                connectionAttributes.getForm().cancel();
             }
         });
 
@@ -168,7 +168,7 @@ public class BridgesList {
         table.setSelectionModel(selectionModel);
         selectionModel.addSelectionChangeHandler(event -> {
             ActivemqBridge activemqBridge = selectionModel.getSelectedObject();
-            if (activemqBridge != null) {
+            if (activemqBridge != null && activemqBridge.getName() != null) {
 
                 ModelNode bridgeModel = presenter.getBridgeAdapter().fromEntity(activemqBridge);
                 for (String connector: activemqBridge.getStaticConnectors()) {
@@ -227,6 +227,8 @@ public class BridgesList {
         credentialRefFormAsset.getForm().clearValues();
         defaultAttributes.getForm().clearValues();
         connectionAttributes.getForm().clearValues();
+        if (bridges.size() == 0)
+            selectionModel.clear();
         SelectionChangeEvent.fire(selectionModel);
     }
 

--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/ui/SecurityDomainView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/ui/SecurityDomainView.java
@@ -99,6 +99,14 @@ public class SecurityDomainView extends ElytronGenericResourceView {
 
     @Override
     protected void onAddCallbackBeforeSubmit(final ModelNode payload) {
+
+        // outflow-anonymous attribute is a boolean with default=false, even if the user doesn't set the field, the
+        // payload sets it as false, then it requires the outflow-security-domains that is undefined
+        // to prevent this error, if the outflow-anonymous is false, we remove from the payload
+        boolean outflowAnonymousUndefined = payload.hasDefined("outflow-anonymous") && !payload.get("outflow-anonymous").asBoolean();
+        if (outflowAnonymousUndefined)
+            payload.remove("outflow-anonymous");
+
         // repackage the payload to create the "realms" attribute of type LIST
         // and create each "realm" from the repackaged description.
         ModelNode realm = new ModelNode();

--- a/gui/src/main/java/org/jboss/as/console/mbui/widgets/ModelNodeFormBuilder.java
+++ b/gui/src/main/java/org/jboss/as/console/mbui/widgets/ModelNodeFormBuilder.java
@@ -497,7 +497,12 @@ public class ModelNodeFormBuilder {
                                         attrDesc.get("max").asLong()
                                 );
                             } else {
-                                formItem = new NumberBoxItem(attr.getName(), label);
+                                boolean allowNegative = false;
+                                if (attrDesc.hasDefined(DEFAULT)) {
+                                    int defNum = attrDesc.get(DEFAULT).asInt();
+                                    allowNegative = defNum < 0;
+                                }
+                                formItem = new NumberBoxItem(attr.getName(), label, allowNegative);
                             }
 
                             formItem.setRequired(isRequired);


### PR DESCRIPTION
* HAL-1326 - Not possible to create security domain in Elytron subsystem configuration without outflow-security-domains attribute specified
* HAL-1325 - It is not possible to set -1 to reconnect attempts attribute of messaging bridge

https://issues.jboss.org/browse/HAL-1325
https://issues.jboss.org/browse/HAL-1326