### PR TITLE
[JBEAP-12293] - Cannot add new credential store with credential reference store field

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/CredentialReferenceFormValidation.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/elytron/CredentialReferenceFormValidation.java
@@ -86,12 +86,14 @@ public class CredentialReferenceFormValidation implements FormValidator {
         if (aliasDefined && !storeDefined) {
             formValidation.addError(store);
             storeFormItem.setErrMessage("This is a required attribute if " + label(alias) + " is used.");
+            storeFormItem.focus();
             storeFormItem.setErroneous(true);
         }
         // validates the alias and store requires each other
         if (storeDefined && !aliasDefined) {
             formValidation.addError(alias);
             aliasFormItem.setErrMessage("This is a required attribute if " + label(store) + " is used.");
+            aliasFormItem.focus();
             aliasFormItem.setErroneous(true);
         }
 
@@ -99,6 +101,7 @@ public class CredentialReferenceFormValidation implements FormValidator {
         if (storeDefined && clearTextDefined) {
             formValidation.addError(clearText);
             clearTextFormItem.setErrMessage("This field should not be used if the following fields are used: " + label(store));
+            clearTextFormItem.focus();
             clearTextFormItem.setErroneous(true);
         }
 

--- a/gui/src/main/java/org/jboss/as/console/mbui/widgets/ModelNodeFormBuilder.java
+++ b/gui/src/main/java/org/jboss/as/console/mbui/widgets/ModelNodeFormBuilder.java
@@ -661,6 +661,7 @@ public class ModelNodeFormBuilder {
                             formValidation.addError(requiredAttrName);
                             item.setErrMessage(
                                     "This is a required attribute if " + sourceFormItem.getTitle() + " is used.");
+                            item.focus();
                             item.setErroneous(true);
                             break;
                         }


### PR DESCRIPTION
Put the 'Credential reference alias' field into focus when the form is invalid.

JBEAP issue: https://issues.jboss.org/browse/JBEAP-12293
HAL issue: https://issues.jboss.org/browse/HAL-1371

This PR depends on  https://github.com/hal/ballroom/pull/23 