### PR TITLE
[HAL-1389] Datasource "Use CCM" value always reported as "false" in the web console

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceConnectionEditor.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/jca/DataSourceConnectionEditor.java
@@ -51,7 +51,7 @@ public class DataSourceConnectionEditor {
 
         TextAreaItem urlItem = new TextAreaItem("connectionUrl", "Connection URL");
         CheckBoxItem jtaItem = new CheckBoxItem("jta", "Use JTA?");
-        CheckBoxItem ccmItem = new CheckBoxItem("use-ccm", "Use CCM?");
+        CheckBoxItem ccmItem = new CheckBoxItem("ccm", "Use CCM?");
 
         ComboBoxItem tx = new ComboBoxItem("transactionIsolation", "Transaction Isolation");
         tx.setValueMap(new String[]{


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/HAL-1389