### PR TITLE
JBEAP-12270 Missing journal-jms-bindings-table field in JMS provider …

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/subsys/activemq/ProviderView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/subsys/activemq/ProviderView.java
@@ -77,6 +77,7 @@ public class ProviderView implements MessagingAddress {
             "journal-database",
             "journal-datasource",
             "journal-file-size",
+            "journal-jms-bindings-table",
             "journal-large-messages-table",
             "journal-max-io",
             "journal-messages-table",


### PR DESCRIPTION
…setting

https://issues.jboss.org/browse/JBEAP-12270

No upstream required.