### PR TITLE
[HAL-1455]Messages Added to a JMS topic is always displayed 0 in the management console

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/shared/runtime/jms/TopicMetrics.java
+++ b/gui/src/main/java/org/jboss/as/console/client/shared/runtime/jms/TopicMetrics.java
@@ -118,7 +118,7 @@ public class TopicMetrics {
                 new NumberColumn("durable-message-count","Durable Message Count"),
                 new NumberColumn("durable-subscription-count","Durable Subscription Count"),
                 new NumberColumn("message-count","Message Count"),
-                new NumberColumn("messages-added ","Messages Added"),
+                new NumberColumn("messages-added","Messages Added"),
                 new NumberColumn("subscription-count","Subscription Count")
 
         };


### PR DESCRIPTION
JIRA:- https://issues.jboss.org/browse/HAL-1455