### PR TITLE
BZ1640047 in order to show more than 100 profiles, set cell list page…

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/domain/profiles/ProfileSelector.java
+++ b/gui/src/main/java/org/jboss/as/console/client/domain/profiles/ProfileSelector.java
@@ -68,6 +68,7 @@ public class ProfileSelector {
 
     public void setProfiles(List<String> profileNames)
     {
+        profiles.setCellListPageSize(profileNames.size());
         profiles.setValues(profileNames);
 
         int index = -1;

--- a/gui/src/main/java/org/jboss/as/console/client/widgets/popups/ComboPicker.java
+++ b/gui/src/main/java/org/jboss/as/console/client/widgets/popups/ComboPicker.java
@@ -183,6 +183,10 @@ public class ComboPicker implements HasValueChangeHandlers<String> {
         this("");
     }
 
+    public void setCellListPageSize(int pageSize) {
+        this.cellList.setPageSize(pageSize);
+    }
+
     public void setClipping(int clipAt) {
         numCharsClip = clipAt;
     }


### PR DESCRIPTION
… size from profiles size
https://bugzilla.redhat.com/show_bug.cgi?id=1640047 
The default page size for cell list in ComboPicker is 100 https://github.com/hal/core/blob/2.5.17.Final/gui/src/main/java/org/jboss/as/console/client/widgets/popups/ComboPicker.java#L108 This causes a problem when there are more than 100 profiles as described in issue.

This does not happen since EAP 7 as commit https://github.com/hal/core/commit/0323b7ceafa7ea516f301da0c92d6607eb1f7574 redesigned the profile display in 2.7.0.Alpha0